### PR TITLE
Relax author line regex to allow name exceptions

### DIFF
--- a/Rfam/Lib/Bio/Rfam/FamilyIO.pm
+++ b/Rfam/Lib/Bio/Rfam/FamilyIO.pm
@@ -661,7 +661,7 @@ sub parseDESC {
           # check AU line in correct format
           chomp($author_line);
           # We need to do this because AU type in DESC is 'ArrayRef[ HashRef ]' type   
-          if ($author_line =~ /^((\S+\s{1}\S{1,3})((\;\s{1})|$)(((\d{4}-){3})\d{3}(\d{1}|X))?){1}$/){
+          if ($author_line =~/^(((\S+\s{1})+\S{1,3})((\;\s{1})|$)(((\d{4}-){3})\d{3}(\d{1}|X))?){1}$/){
             
            # aplit author line to author fields (name, orcid)
            my @author_fields = (split /;/, $author_line);


### PR DESCRIPTION
The new author name regex fixes some author name exceptions e.g. "de la pena M". 