### PR TITLE
New QC step to check if all SEED sequences match the CM

### DIFF
--- a/Rfam/Scripts/qc/rqc-all.pl
+++ b/Rfam/Scripts/qc/rqc-all.pl
@@ -144,7 +144,8 @@ $error = 0;
 
 #Check the SEED
 eval{
-  $error = Bio::Rfam::QC::compareSeedAndScores($familyObj);
+  #$error = Bio::Rfam::QC::compareSeedAndScores($familyObj);
+  $error = Bio::Rfam::QC::checkAllSeedSequencesMatchCm($familyObj, $config, "$pwd/$family");
 };
 print $L $@ if($@);
 if($error){

--- a/Rfam/Scripts/qc/rqc-check.pl
+++ b/Rfam/Scripts/qc/rqc-check.pl
@@ -42,7 +42,8 @@ if(-e "$family/check"){
 
 my $error = 0;
 #See if all sequences are recovered.
-$error = Bio::Rfam::QC::compareSeedAndScores($familyObj);
+#$error = Bio::Rfam::QC::compareSeedAndScores($familyObj);
+$error = Bio::Rfam::QC::checkAllSeedSequencesMatchCm($familyObj, $config, "$pwd/$family");
 
 #Check that the family already exists.
 eval{


### PR DESCRIPTION
One of the QC steps (`compareSeedAndScores`) checks that all SEED sequences are found in the SCORES file. However, this is no longer true because starting with Rfam 14.1 some SEED sequences may not be found in Rfamseq, so they will not be included in the SCORES file. 

This pull request adds a new function `checkAllSeedSequencesMatchCm` that replaces `compareSeedAndScores` to make sure that all SEED sequences are found by the CM.

I tested it on the cluster with the 6A family:
https://xfamsvn.ebi.ac.uk/svn/data_repos/trunk/Families/RF02925/SEED

The previous revision of the SEED alignment contained the sequence URS0000D67F07_12908 that does not match the CM and fails the new QC. The current version of the alignment has been updated and does not contain that sequence anymore so it passes the new QC step.

Any comments are welcome.