### PR TITLE
Fixes undefined subroutine call

### DIFF
--- a/Rfam/Scripts/qc/rqc-all.pl
+++ b/Rfam/Scripts/qc/rqc-all.pl
@@ -144,7 +144,7 @@ $error = 0;
 
 #Check the SEED
 eval{
-  $error = Bio::Rfam::QC::compareSeedAndScores($familyObj);
+  $error = Bio::Rfam::QC::compareSeedAndSeedScores($familyObj);
 };
 print $L $@ if($@);
 if($error){


### PR DESCRIPTION
Updates `compareSeedAndScores` to `compareSeedAndSeedScores` which was updated during `rfci-md5` refactorization.