### PR TITLE
Relaxes strictness of regex that matches HMM STATS lines in CM file t…

### DIFF
--- a/Rfam/Lib/Bio/Rfam/FamilyIO.pm
+++ b/Rfam/Lib/Bio/Rfam/FamilyIO.pm
@@ -525,11 +525,11 @@ sub _parseCMHMMHeader {
       $objHash->{hitTC} = $1;
     } elsif (/NC\s+(\S+)\;/) { 
       $objHash->{hitNC} = $1;
-    } elsif ( my ($msv_mu, $msv_lambda ) = $_ =~ /^STATS LOCAL MSV\s+(\S+)\s+(0\.\d+)/) {
+    } elsif ( my ($msv_mu, $msv_lambda ) = $_ =~ /^STATS LOCAL MSV\s+(\S+)\s+(\d+\.\d+)/) {
       $objHash->{msvStats} = { mu => $msv_mu, lambda => $msv_lambda};
-    } elsif ( my ($viterbi_mu, $viterbi_lambda ) = $_ =~ /^STATS LOCAL VITERBI\s+(\S+)\s+(0\.\d+)/) {
+    } elsif ( my ($viterbi_mu, $viterbi_lambda ) = $_ =~ /^STATS LOCAL VITERBI\s+(\S+)\s+(\d+\.\d+)/) {
       $objHash->{viterbiStats} = { mu => $viterbi_mu, lambda => $viterbi_lambda };
-    } elsif ( my ($forward_tau, $forward_lambda ) = $_ =~ /^STATS LOCAL FORWARD\s+(\S+)\s+(0\.\d+)/) {
+    } elsif ( my ($forward_tau, $forward_lambda ) = $_ =~ /^STATS LOCAL FORWARD\s+(\S+)\s+(\d+\.\d+)/) {
       $objHash->{forwardStats} = {tau => $forward_tau, lambda => $forward_lambda};
     } elsif ( $_ =~ /^HMM\s+A/) {
       $$iRef = $i;


### PR DESCRIPTION
…o accomodate lambda values that are greater than 1 (which can happen with very short models).

This bug was reported by Alberto L'Abbate using a CM built from the following single seq:
>NM_167118.2/506-520
TATTTTTTTTCACAG

via slack, 'Rfam Cloud' channel on 7/30/20.