### PR TITLE
RNAcentral QC fix

### DIFF
--- a/Rfam/Lib/Bio/Rfam/QC.pm
+++ b/Rfam/Lib/Bio/Rfam/QC.pm
@@ -1236,7 +1236,7 @@ sub checkSEEDSeqs_helper {
       }
     }
     if($rnacentral_has_seq_by_md5) {
-      if($rnacentral_md5 ne $seed_md5) {
+      if($rnacentral_seq_md5 ne $seed_md5) {
         # 7) subseq appears to exist in RNAcentral, but md5 does not match
         #    (THIS SHOULD BE IMPOSSIBLE BECAUSE WE LOOK UP IN RNACENTRAL BASED ON md5)
         $passfail = "FAIL";

--- a/Rfam/Lib/Bio/Rfam/QC.pm
+++ b/Rfam/Lib/Bio/Rfam/QC.pm
@@ -13,9 +13,9 @@ A more detailed description of what this class does and how it does it.
 
 =head1 COPYRIGHT
 
-File: QC.pm 
+File: QC.pm
 
-Copyright (c) 2013: 
+Copyright (c) 2013:
 
 
 Author: Rob Finn (rdf 'at' ebi.ac.uk or finnr 'at' janelia.hhmi.org)
@@ -36,16 +36,16 @@ use IPC::Run qw(run);
 
 =cut
 
-#Templating this off the old code......
+#Templating this off the old code.....
 sub checkFamilyFiles {
   my ( $family, $upFamilyObj ) = @_;
-  
+
   #Removed QC check below; this is now conducted as part of the checkin, and
   #not prior to checkin as it was in Sanger. Therefore no point looking for
   #qcpassed file:
 
   #&checkQCPerformed($family, $upFamilyObj);
-  
+
   #Now return result of timestamp check:
   return checkTimestamps($family,$upFamilyObj);
 	#return 1 on failure.
@@ -81,8 +81,8 @@ sub checkQCPerformed {
   Usage    : Bio::Rfam::QC::checkFamily($familyObj)
   Function : Performs series of format checks
   Args     : A Bio::Rfam::Family object
-  Returns  : 1 if an error is found, 
-  
+  Returns  : 1 if an error is found,
+
 =cut
 
 sub checkFamilyFormat {
@@ -121,7 +121,7 @@ sub checkFamilyFormat {
   Function : Performs format QC steps on the SEED, via the object.
   Args     : A Bio::Rfam::Family object
   Returns  : 1 on error, 0 on passing checks.
-  
+
 =cut
 
 sub checkSEEDFormat {
@@ -164,18 +164,18 @@ sub checkSEEDFormat {
     warn "FATAL: SEED does not have an SS_cons line\n";
     $error++;
   }
-  
+
   #If family is a lncRNA, ensure it does not have any secondary
   #structure in the SS line.
-  if( defined($familyObj->DESC->TP) and 
+  if( defined($familyObj->DESC->TP) and
       $familyObj->DESC->TP eq 'Gene; lncRNA;' ){
       if(!($familyObj->SEED->get_ss_cons =~ /^(\.|\:)*$/)){
         warn "Found family type lncRNA (TP line in DESC), but the seed contains secondary structure.\n";
         $error++;
       }
-    
+
   }
-  
+
   return $error;
 }
 
@@ -190,10 +190,10 @@ sub checkSEEDFormat {
            : Although largely done via the FamilyIO, that just parses fields and
            : does not perform integrity checks. This checks that the number of
            : SEED sequences and CM are consistent and that the number of sequences
-           : in the CM and internal HMM agree. 
+           : in the CM and internal HMM agree.
   Args     : A Bio::Rfam::Family object
   Returns  : 1 on error, 0 on passing checks.
-  
+
 =cut
 
 sub checkCMFormat {
@@ -221,20 +221,20 @@ sub checkCMFormat {
   }
 
   # Make sure the checksums match between the SEED and the CM
-  if($familyObj->CM->cmHeader->{cksum} != $familyObj->SEED->checksum) { 
+  if($familyObj->CM->cmHeader->{cksum} != $familyObj->SEED->checksum) {
     $error = 1;
     # checksums don't match, SEED may not be in digital mode
-    if(! $familyObj->SEED->is_digitized) { 
+    if(! $familyObj->SEED->is_digitized) {
       printf STDERR ("Checksum mismatch between SEED and CM, possibly because SEED was read in text mode, inspect Bio::Rfam::Family object declaration.\n");
     }
-    else { 
+    else {
       printf STDERR ("Checksum mismatch between SEED and CM, CM was not built from SEED.\n");
     }
     return $error;
   }
 
   # Make sure the CLEN in the CM is the same as the nongap RF length in the SEED
-  if(! $familyObj->SEED->has_rf) { 
+  if(! $familyObj->SEED->has_rf) {
     printf STDERR "FATAL: SEED does not have an RF line\n";
     $error = 1;
     return $error;
@@ -245,7 +245,7 @@ sub checkCMFormat {
     printf STDERR ("FATAL: CLEN in CM does not match nogap RF length in SEED.\n");
     $error = 1;
     return $error;
-  }    
+  }
 
   return $error;
 }
@@ -260,7 +260,7 @@ sub checkCMFormat {
   Function : Performs format QC steps on the DESC, via the object.
   Args     : A Bio::Rfam::Family object
   Returns  : 1 on error, 0 on passing checks.
-  
+
 =cut
 
 sub checkDESCFormat {
@@ -300,7 +300,7 @@ sub checkDESCFormat {
   Function : Performs format QC steps on the scores, via the object.
   Args     : A Bio::Rfam::Family object
   Returns  : 1 on error, 0 on passing checks.
-  
+
 =cut
 
 sub checkScoresFormat {
@@ -308,16 +308,16 @@ sub checkScoresFormat {
 
   my $threshold = $familyObj->DESC->CUTGA;
   #Should check that no regions exceed threshold?
-  
+
   #Now we have to ensure that all sequences are present and correct w.r.t to the
   #GA threshold. Run over the TBLOUT file and get all data from that raw,
   #infernal output.
 
   my $count = 0;
   my(@tbloutMatches, $nres);
-  open(T, '<', $familyObj->TBLOUT->fileLocation) 
+  open(T, '<', $familyObj->TBLOUT->fileLocation)
       or die "Failed to open TBLOUT file for reading.[$!]\n";
-  
+
   while(<T>){
     next if(/^#/); #Ignore lines starting with #
     my @line = split(/\s+/); #split on whitespace
@@ -346,26 +346,26 @@ sub checkScoresFormat {
          "] array differs from the count [". ($familyObj->SCORES->numRegions) ."].\n";
     $error = 1;
   }
-  
+
   $familyObj->SCORES->determineNres if(!$familyObj->SCORES->nres);
   if($nres != $familyObj->SCORES->nres){
     warn "The number of residues in the SCORES [".$familyObj->SCORES->nres.
           "] and TBLOUT [$nres] do not match.\n";
   }
-  
+
   return($error) if($error);
 
   #Now a deep comparison, if everything looks okay. Do this by making a string
   #out of all of the NSE from the TBLOUT and SCORES - then compare.
-  my $scoresMatches = join(" ", 
-                           sort { $a cmp $b } 
+  my $scoresMatches = join(" ",
+                           sort { $a cmp $b }
                            map { $_->[0]   }
                            @{$familyObj->SCORES->regions});
-  
+
   my $tbloutMatches = join(" ", sort { $a cmp $b } @tbloutMatches);
 
   if($scoresMatches ne $tbloutMatches){
-    warn "The matches between SCORES and TBLOUT differ!\n"; 
+    warn "The matches between SCORES and TBLOUT differ!\n";
     $error = 1;
   }
   return($error);
@@ -382,7 +382,7 @@ sub checkScoresFormat {
            : are present in the DESC file.
   Args     : A Bio::Rfam::Family object, a Bio::Rfam::Config object (optional).
   Returns  :  1 on error, 0 on passing checks.
-  
+
 =cut
 
 sub checkRequiredFields {
@@ -414,12 +414,12 @@ sub checkRequiredFields {
   }
 
   #Make sure none of the default values set in writeEmptyDESC still exist
-  foreach my $key ( keys %{ $familyObj->DESC->defaultButIllegalFields } ) { 
+  foreach my $key ( keys %{ $familyObj->DESC->defaultButIllegalFields } ) {
     if ( !defined( $familyObj->DESC->$key ) ) { #make sure it's defined first
       warn "Required DESC field $key not defined.\n";
       $error++;
     }
-    elsif( $familyObj->DESC->$key eq $familyObj->DESC->defaultButIllegalFields->{$key} ) { 
+    elsif( $familyObj->DESC->$key eq $familyObj->DESC->defaultButIllegalFields->{$key} ) {
       warn "DESC field $key illegal value (appears unchanged from an 'rfsearch.pl -nodesc' call).\n";
       $error++;
     }
@@ -427,9 +427,9 @@ sub checkRequiredFields {
     # a special case: make sure that --nohmmonly appears in the SM (search method)
     # so we can't check-in a family run with the -hmmonly option in rfsearch, which
     # is meant to be a option used for debugging only, not for production.
-    if(defined $familyObj->DESC->SM) { 
-      if($familyObj->DESC->SM !~ m/\-\-nohmmonly/) { 
-        warn "DESC SM field does not contain --nohmmonly.\n"; 
+    if(defined $familyObj->DESC->SM) {
+      if($familyObj->DESC->SM !~ m/\-\-nohmmonly/) {
+        warn "DESC SM field does not contain --nohmmonly.\n";
         $error++;
       }
     }
@@ -474,7 +474,7 @@ sub checkRequiredFields {
            : the expected data structure that is stored in the config.
   Args     : A Bio::Rfam::Family object, a Bio::Rfam::Config object (optional)
   Returns  : 0 if everything is okay, 1 if there is an error detected.
-  
+
 =cut
 
 sub checkTPField {
@@ -532,22 +532,22 @@ sub checkTPField {
   Function : Checks that nobody has changes the ID, AC, PI lines
   Args     : Bio::Rfam::Family object for old and new family.
   Returns  : 1 on error, 0 on success.
-  
+
 =cut
 
 sub checkFixedFields {
   my ($newFamilyObj, $oldFamilyObj) = @_;
-  
+
   my $error = 0;
-  
+
   if ( !$newFamilyObj or !$newFamilyObj->isa('Bio::Rfam::Family') ) {
     die "Did not get passed in a Bio::Rfam::Family object (new)\n";
   }
-  
+
   if ( !$oldFamilyObj or !$oldFamilyObj->isa('Bio::Rfam::Family') ) {
     die "Did not get passed in a Bio::Rfam::Family object (old)\n";
   }
-  
+
   if($newFamilyObj->DESC->AC ne $oldFamilyObj->DESC->AC){
     warn "Your accession (AC) differs between the old and new version of the family.\n";
     $error = 1;
@@ -557,14 +557,14 @@ sub checkFixedFields {
     warn "Your identifier (ID) differs between the old and new version of the family.\n";
     $error = 1;
   }
-  
+
   if( defined( $newFamilyObj->DESC->PI )){
     if($newFamilyObj->DESC->PI ne $oldFamilyObj->DESC->PI){
       warn "Your pervious identifers (PI) differs between the old and new version of the family.\n";
       $error = 1;
     }
   }
-  
+
   return $error;
 }
 
@@ -578,22 +578,22 @@ sub checkFixedFields {
   Function : Checks that nobody has changes the ID, AC, PI and MB lines
   Args     : Bio::Rfam::Clan object for old and new clan.
   Returns  : 1 on error, 0 on success.
-  
+
 =cut
 
 sub checkClanFixedFields {
   my ($newClanObj, $oldClanObj) = @_;
-  
+
   my $error = 0;
-  
+
   if ( !$newClanObj or !$newClanObj->isa('Bio::Rfam::Clan') ) {
     die "Did not get passed in a Bio::Rfam::Clan object (new)\n";
   }
-  
+
   if ( !$oldClanObj or !$oldClanObj->isa('Bio::Rfam::Clan') ) {
     die "Did not get passed in a Bio::Rfam::Clan object (old)\n";
   }
-  
+
   if($newClanObj->DESC->AC ne $oldClanObj->DESC->AC){
     warn "Your accession (AC) differs between the old and new version of the clan.\n";
     $error = 1;
@@ -603,14 +603,14 @@ sub checkClanFixedFields {
     warn "Your identifier (ID) differs between the old and new version of the clan.\n";
     $error = 1;
   }
-  
+
   if( defined( $newClanObj->DESC->PI )){
     if($newClanObj->DESC->PI ne $oldClanObj->DESC->PI){
       warn "Your pervious identifers (PI) differs between the old and new version of the Clan. This should be performed by CL move.\n";
       $error = 1;
     }
   }
-  
+
   #Now compare the membership of the old and new to check that nobody has change it here.
   my $old_members = defined $oldClanObj->DESC->MEMB ? $oldClanObj->DESC->MEMB : [];
   my $new_members = defined $newClanObj->DESC->MEMB ? $newClanObj->DESC->MEMB : [];
@@ -636,7 +636,7 @@ sub checkClanFixedFields {
         : "$d is not in the new membership\n";
     }
   }
-  
+
   return $error;
 }
 
@@ -646,11 +646,11 @@ sub checkClanFixedFields {
   Title    : checkNonFreeText
   Incept   : finnr, Aug 5, 2013 11:03:29 AM
   Usage    : Bio::Rfam::QC::checkNonFreeText($newFamilyObj, $oldFamilyObj)
-  Function : Checks that certain fields in the DESC have not changed between 
+  Function : Checks that certain fields in the DESC have not changed between
            : different the checked-in and modified versions
   Args     : Bio::Rfam::Family object for both the old and updated families.
   Returns  : 1 on error, 0 on success.
-  
+
 =cut
 
 sub checkNonFreeText {
@@ -661,11 +661,11 @@ sub checkNonFreeText {
   if ( !$upFamilyObj or !$upFamilyObj->isa('Bio::Rfam::Family') ) {
     die "Did not get passed in a Bio::Rfam::Family object\n";
   }
-  
+
   if ( !$oldFamilyObj or !$oldFamilyObj->isa('Bio::Rfam::Family') ) {
     die "Did not get passed in a Bio::Rfam::Family object\n";
   }
-  
+
   #The list of fields  that cannot be altered are:
   # NC, TC, GA,
   my $error = 0;
@@ -689,7 +689,7 @@ sub checkNonFreeText {
       $error = 1;
     }
   }
-  
+
   return ($error);
 }
 #------------------------------------------------------------------------------
@@ -705,7 +705,7 @@ sub checkNonFreeText {
            : just sequence accessions.
   Args     : A Bio::Rfam::Family object
   Returns  : 0 when all sequences found, otherwise 1
-  
+
 =cut
 
 sub compareSeedAndSeedScores {
@@ -715,7 +715,7 @@ sub compareSeedAndSeedScores {
     die "Did not get passed in a Bio::Rfam::Family object\n";
   }
 
-  if (!$familyObj->SEEDSCORES) { 
+  if (!$familyObj->SEEDSCORES) {
     die "ERROR in compareSeedAndSeedScores() no SEEDSCORES object exists";
   }
 
@@ -756,13 +756,13 @@ sub compareSeedAndSeedScores {
   Usage    : Bio::Rfam::QC::compareOldAndNew($oldFamily, $updatedFamily, $path)
   Function : Compares the SCORES files from the old and update family to identify
            : new and missing sequences. If a path is supplied, it will write files
-           : containing the found/missing sequence accessions 
+           : containing the found/missing sequence accessions
   Args     : Two family objects, first the old, second the updated family.  Third
            : argument is an optional path of the directory where missng and found
            : files should be written
-  Returns  : array references to the arrays containing the found or missing 
+  Returns  : array references to the arrays containing the found or missing
            : sequence accessions.
-  
+
 =cut
 
 sub compareOldAndNew {
@@ -850,7 +850,7 @@ sub compareOldAndNew {
            : that have been built in the same way.
   Args     : A path to family directory, a Bio::Rfam::Config object (optional).
   Returns  : 0 on passing, 1 on issue.
-  
+
 =cut
 
 sub checkTimestamps {
@@ -873,22 +873,22 @@ sub checkTimestamps {
     if ( !-e "$fam/$f" ) {
       warn "$f is missing from $fam\n";
       $error++;
-    } 
+    }
   }
   return $error if ($error);
 
   #Now check the timestamps.
-	if(Bio::Rfam::Utils::youngerThan("$fam/SEED", "$fam/CM")) { 
+	if(Bio::Rfam::Utils::youngerThan("$fam/SEED", "$fam/CM")) {
     warn
         "\nFATAL ERROR: $fam: Your SEED [$fam/SEED] is younger than your CM file [$fam/CM].\n";
     $error = 1;
   }
-  if(Bio::Rfam::Utils::youngerThan("$fam/CM", "$fam/TBLOUT")) { 
+  if(Bio::Rfam::Utils::youngerThan("$fam/CM", "$fam/TBLOUT")) {
     warn
 "\nFATAL ERROR: $fam: Your CM [$fam/CM] is younger than your TBLOUT file [$fam/TBLOUT].\n";
     $error = 1;
   }
-  if(Bio::Rfam::Utils::youngerThan("$fam/TBLOUT", "$fam/SCORES")) { 
+  if(Bio::Rfam::Utils::youngerThan("$fam/TBLOUT", "$fam/SCORES")) {
     warn
 "\nFATAL ERROR: $fam: Your TBLOUT [$fam/TBLOUT] is younger than your scores [$fam/scores].\n";
     $error = 1;
@@ -905,12 +905,12 @@ sub checkTimestamps {
   Usage    : Bio::Rfam::QC::checkSpell($dir, $dictPath, $familyIOObj)
   Function : This takes the DESC file and grabs out the free text fields, removes
            : our tags and writes a temporary file. It then runs ispell over the
-           : contents of the file, interactively with the users. Finally, the 
+           : contents of the file, interactively with the users. Finally, the
            : data is written back into the file.
   Args     : Path containting the family, Path to dictionary file used by ispell,
            : a familyIO object (optional)
   Returns  : An error flag if encountered.
-  
+
 =cut
 
 sub checkSpell {
@@ -1046,11 +1046,11 @@ sub checkSpell {
   Incept   : EPN, Thu Jul 18 15:34:22 2013
   Usage    : Bio::Rfam::QC::ssStats($familyObj, $outputDir)
   Function : Calculates and outputs per-family, per-sequence and per-basepair
-           : statistics to 'ss-stats-perfamily', 'ss-stats-persequence' and 
+           : statistics to 'ss-stats-perfamily', 'ss-stats-persequence' and
            : 'ss-stats-perbasepair' files.
   Args     : A Family object, output directory (optional, default '.').
   Returns  : 1 on error, 0 if no errors were found.
-  
+
 =cut
 
 sub ssStats {
@@ -1090,16 +1090,16 @@ sub ssStats {
   Incept   : EPN, Fri Mar  1 18:04:58 2019
   Usage    : Bio::Rfam::QC::checkSEEDSeqs($familyObj, $seqDBObj, $be_verbose)
   Function : Checks that all SEED sequencs are valid based on md5
-           : To be valid, each SEED sequence must exist and 
+           : To be valid, each SEED sequence must exist and
            : (be identical to) the same (sub)sequence in one
-           : or more of: 
+           : or more of:
            : - rfamseq
            : - GenBank
            : - RNAcentral
   Args     : Bio::Rfam::Family object, Bio::Rfam::SeqDB object
            : $be_verbose: if '1' print info to stdout, if '0' print warnings only if nec.
   Returns  : 1 on error, 0 on successully passing check
-  
+
 =cut
 
 sub checkSEEDSeqs {
@@ -1123,25 +1123,25 @@ sub checkSEEDSeqs {
   Usage    : Bio::Rfam::QC::checkSEEDSeqs($familyObj, $seqDBObj)
   Function : Does actual work for checkSEEDSeqs()
            : Checks that all SEED sequencs are valid based on md5
-           : To be valid, each SEED sequence must exist and 
+           : To be valid, each SEED sequence must exist and
            : (be identical to) the same (sub)sequence in one
-           : or more of: 
+           : or more of:
            : - rfamseq
            : - GenBank
            : - RNAcentral
   Args     : Bio::Easel::MSA object, Bio::Rfam::Family object, Bio::Rfam::SeqDB object
            : $be_verbose: if '1' print info to stdout, if '0' print warnings only if nec.
   Returns  : 1 on error, 0 on successully passing check
-  
+
 =cut
 sub checkSEEDSeqs_helper {
   my ( $seed, $seqDBObj, $be_verbose ) = @_;
 
-  # stats collected and only output if $be_verbose is 1 
+  # stats collected and only output if $be_verbose is 1
   my $nrfm_pass = 0;
   my $ngbk_pass = 0;
   my $nrnc_pass = 0;
-  my $nfail = 0; 
+  my $nfail = 0;
 
   if(! defined $be_verbose) { $be_verbose = 0; }
 
@@ -1154,17 +1154,17 @@ sub checkSEEDSeqs_helper {
 
     my $seed_msa_seq = $seed->get_sqstring_unaligned($i);
     my $seed_md5 = Bio::Rfam::Utils::md5_of_sequence_string($seed_msa_seq);
-    
+
     # lookup in rfamseq
     my ($rfamseq_has_source_seq, $rfamseq_has_exact_seq, $rfamseq_md5) = Bio::Rfam::Utils::rfamseq_nse_lookup_and_md5($seqDBObj, $nse);
-    
+
     # lookup in GenBank, retry up to 200 times if fetch fails, wait 3 seconds between tries
     my ($genbank_has_source_seq, $genbank_has_exact_seq, $genbank_md5) = Bio::Rfam::Utils::genbank_nse_lookup_and_md5($nse, 200, 3);
-    
+
     # lookup in RNAcentral
     my ($rnacentral_has_exact_seq, $rnacentral_md5, $rnacentral_id, undef) = Bio::Rfam::Utils::rnacentral_md5_lookup($seed_md5);
-    
-    # 
+
+    #
     my $pass_rfm = 0;
     my $pass_gbk = 0;
     my $pass_rnc = 0;
@@ -1181,57 +1181,57 @@ sub checkSEEDSeqs_helper {
     # 7) subseq appears to exist in RNAcentral, but md5 does not match
     #    (THIS SHOULD BE IMPOSSIBLE BECAUSE WE LOOK UP IN RNACENTRAL BASED ON md5)
     # 8) subseq appears to exist in RNAcentral, but it is not in URS_taxid format
-    if(! $is_nse) { 
+    if(! $is_nse) {
       # 1) name is not in valid name/start-end format
       $passfail = "FAIL";
       if($be_verbose) { $outstr .= "NOT-NAME/START-END"; }
       else            { warn "SEED sequence $nse fails validation; it is not in valid name/start-end format\n"; }
     }
-    if((! $rfamseq_has_source_seq) && (! $genbank_has_source_seq) && (! $rnacentral_has_exact_seq)) { 
+    if((! $rfamseq_has_source_seq) && (! $genbank_has_source_seq) && (! $rnacentral_has_exact_seq)) {
       # 2) not in any of Rfamseq, GenBank, or RNAcentral
       $passfail = "FAIL";
       if($be_verbose) { $outstr .= "NO-MATCHES"; }
       else            { warn "SEED sequence $nse fails validation; it exists in none of: Rfamseq, GenBank, RNAcentral\n"; }
     }
-    if(($rfamseq_has_source_seq) && (! $rfamseq_has_exact_seq)) { 
+    if(($rfamseq_has_source_seq) && (! $rfamseq_has_exact_seq)) {
       # 3) source seq exists in Rfamseq, but not subseq (start-end)
       $passfail = "FAIL";
       if($be_verbose) { $outstr .= "RFM:found-seq-but-not-subseq;"; }
       else            { warn "SEED sequence $nse fails validation; its source sequence exists in Rfamseq, but specific range subsequence does not\n"; }
     }
-    if(($genbank_has_source_seq) && (! $genbank_has_exact_seq)) { 
+    if(($genbank_has_source_seq) && (! $genbank_has_exact_seq)) {
       # 4) source seq exists in GenBank, but not subseq (start-end)
       $passfail = "FAIL";
       if($be_verbose) { $outstr .= "GBK:found-seq-but-not-subseq;"; }
       else            { warn "SEED sequence $nse fails validation; its source sequence exists in GenBank, but specific range subsequence does not\n"; }
     }
-    if($rfamseq_has_exact_seq) { 
+    if($rfamseq_has_exact_seq) {
       if($rfamseq_md5 ne $seed_md5) {
         # 5) subseq appears to exist in Rfamseq, but md5 does not match
         $passfail = "FAIL";
         if($be_verbose) { $outstr .= "RFM:md5-fail;"; }
         else            { warn "SEED sequence $nse fails validation; it appears to exist in Rfamseq, but md5 does not match\n"; }
       }
-      else { 
+      else {
         $nrfm_pass++;
         $pass_rfm = 1;
         if($be_verbose) { $outstr .= "RFM:md5-pass;"; }
-      }      
-    }  
-    if($genbank_has_exact_seq) { 
+      }
+    }
+    if($genbank_has_exact_seq) {
       if($genbank_md5 ne $seed_md5) {
         # 6) subseq appears to exist in GenBank, but md5 does not match
         $passfail = "FAIL";
         if($be_verbose) { $outstr .= "GBK:md5-fail;"; }
         else            { warn "SEED sequence $nse fails validation; it appears to exist in GenBank, but md5 does not match\n"; }
       }
-      else { 
+      else {
         $ngbk_pass++;
         $pass_gbk = 1;
         if($be_verbose) { $outstr .= "GBK:md5-pass;"; }
       }
     }
-    if($rnacentral_has_exact_seq) { 
+    if($rnacentral_has_exact_seq) {
       if($rnacentral_md5 ne $seed_md5) {
         # 7) subseq appears to exist in RNAcentral, but md5 does not match
         #    (THIS SHOULD BE IMPOSSIBLE BECAUSE WE LOOK UP IN RNACENTRAL BASED ON md5)
@@ -1239,13 +1239,13 @@ sub checkSEEDSeqs_helper {
         if($be_verbose) { $outstr .= "RNC:md5-fail;"; }
         else            { warn "SEED sequence $nse fails validation; it appears to exist in RNAcentral, but md5 does not match (*check code: this should be impossible)\n"; }
       }
-      else { 
+      else {
         # 8) subseq only exists in RNAcentral, but is not in URS_taxid format
-        # if the sequence *only* exists in RNAcentral verify that it 
+        # if the sequence *only* exists in RNAcentral verify that it
         # has the proper name format URS_taxid
-        if((! $pass_rfm) && (! $pass_gbk)) { 
+        if((! $pass_rfm) && (! $pass_gbk)) {
           my ($is_rnacentral_taxid, undef, undef) = Bio::Rfam::Utils::rnacentral_urs_taxid_breakdown(($is_nse) ? $name : $nse);
-          if($is_rnacentral_taxid != 1) { 
+          if($is_rnacentral_taxid != 1) {
             $passfail = "FAIL";
             if($be_verbose) { $outstr .= "RNC:md5-id-pass;"; }
             else            { warn "SEED sequence $nse fails validation; it is only in RNAcentral, but its name is not in the expected URS_taxid format\n"; }
@@ -1257,11 +1257,11 @@ sub checkSEEDSeqs_helper {
     if($passfail eq "FAIL") { $nfail++; }
   }
 
-  if($nfail > 0) { 
+  if($nfail > 0) {
     warn "script Rfam/Scripts/jiffies/validate_seed_sequences_against_database.pl can provide more information";
   }
 
-  if($be_verbose) { 
+  if($be_verbose) {
     print("nseq:      $nseq\n");
     print("nrfm_pass: $nrfm_pass\n");
     print("ngbk_pass: $ngbk_pass\n");
@@ -1270,7 +1270,7 @@ sub checkSEEDSeqs_helper {
   }
 
   # return value differs depending on $be_verbose value:
-  if($be_verbose) { 
+  if($be_verbose) {
     return $nfail;
   }
   return ($nfail > 0) ? 1 : 0; # return 1 if at least 1 seq failed
@@ -1284,13 +1284,13 @@ sub checkSEEDSeqs_helper {
   Usage    : Bio::Rfam::QC::checkSEEDSeqsNameOnly($familyObj, $seqDBObj, $be_verbose)
   Function : Checks each SEED sequencs to see if a sequence of the
            : same name exists in rfamseq. Note, doesn't remove "/<start>-<end>"
-           : from the SEED sequence name if it exists, it checks the 
+           : from the SEED sequence name if it exists, it checks the
            : entire sequence name, possibly including "/<start>-<end>"
-           : 
+           :
   Args     : Bio::Rfam::Family object
            : Bio::Rfam::SeqDB object
   Returns  : List of sequences that fail the name check, "" on successully passing check
-  
+
 =cut
 
 sub checkSEEDSeqsNameOnly {
@@ -1309,12 +1309,12 @@ sub checkSEEDSeqsNameOnly {
   for ( my $i = 0 ; $i < $nseq; $i++ ) {
     my $name = $seed->get_sqname($i);
     my $name_exists_in_db = $seqDBObj->check_seq_exists($name) ? 1 : 0;
-    if($name_exists_in_db) { 
+    if($name_exists_in_db) {
       $name_str .= "\t$name\n";;
     }
   }
-  if($name_str ne "") { 
-    $ret_str  = "The following sequence names exist in both the SEED and the target db.\n"; 
+  if($name_str ne "") {
+    $ret_str  = "The following sequence names exist in both the SEED and the target db.\n";
     $ret_str .= "Change their names in SEED, preferable to <name>/<start>-<end>\n";
     $ret_str .= $name_str;
   }
@@ -1328,9 +1328,9 @@ sub checkSEEDSeqsNameOnly {
   Title    : checkScoresSeqs
   Incept   : finnr, Jul 31, 2013 2:54:26 PM
   Usage    : Bio::Rfam::QC::checkScoresSeqs($familyObj, $seqDBObj)
-  Function : 
-  Args     : 
-  Returns  : 
+  Function :
+  Args     :
+  Returns  :
 
 =cut
 
@@ -1361,11 +1361,11 @@ sub checkScoresSeqs {
 
   Title    : checkOverlaps
   Incept   : finnr, Aug 5, 2013 4:08:00 PM
-  Usage    : 
-  Function : 
-  Args     : 
-  Returns  : 
-  
+  Usage    :
+  Function :
+  Args     :
+  Returns  :
+
 =cut
 
 sub checkOverlaps {
@@ -1382,15 +1382,15 @@ sub checkOverlaps {
 #is the family part of a clan?
     if ($familyObj->DESC->CL) {
         my $clan = $familyObj->DESC->CL;
-#get clan membership and add members to ignore hash        
+#get clan membership and add members to ignore hash
         my @rs = $rfamdb->resultset('ClanMembership')->search( { clan_acc => $clan });
         foreach my $row (@rs){
             my $rfam_acc = $row->rfam_acc->rfam_acc;
             $ignore->{$rfam_acc}=1;
         }
-    }  
+    }
 
-  open(my $OVERLAP, '>', "$famPath/overlap") 
+  open(my $OVERLAP, '>', "$famPath/overlap")
     or die "Could not open $famPath/overlap:[$!]\n";
 
   my $error = 0;
@@ -1399,9 +1399,9 @@ sub checkOverlaps {
   $masterError =  1 if($error);
   $error = findInternalOverlaps($familyObj, $OVERLAP);
   $masterError =  1 if($error);
-  
+
   close($OVERLAP);
-  
+
   return $masterError;
 }
 
@@ -1438,13 +1438,13 @@ sub findClanOverlaps {
 	#
 	for my $family (@$clan_members) {
 		my $regions = $rfamdb->resultset('FullRegion')->allRegions($family);
-	
+
 	#For each region, get start and end coordinates and figure out which strand it is on:
 	#
 		for my $r ( @$regions) {
-			my ($s1, $e1, $strand) = 
+			my ($s1, $e1, $strand) =
         	$r->[1] <= $r->[2] ? ($r->[1], $r->[2], 1) : ($r->[2], $r->[1], -1);
-		
+
 	# Add hash of each region to the clan_regions array:
 	#
 		push @clan_regions , {rfamseq_acc => $r->[3],
@@ -1454,8 +1454,8 @@ sub findClanOverlaps {
 						evalue => $r->[5],
 						family => $family,
 						type => $r->[9]};
-	
-		}	
+
+		}
 	}
  	# Now look for overlaps for every region:
  	#
@@ -1470,7 +1470,7 @@ sub findClanOverlaps {
 	#
 		my $ol = 0;
 		my @overlaps;
-	
+
 	# Now, compare our query sequence with every other region in the clan:
 	#
 		for my $poss_overlap( @clan_regions) {
@@ -1479,7 +1479,7 @@ sub findClanOverlaps {
 			if ($region->{family} eq $poss_overlap->{family}) {
 				next;
 			}
-			
+
 
 			#Ignore any sequence accessions which we have seen before, as we will already have
 			#checked these for overlaps:
@@ -1497,7 +1497,7 @@ sub findClanOverlaps {
 			my ($s2, $e2) = ($poss_overlap->{start}, $poss_overlap->{end});
 			my $overlap = 0;
 			#Now calculate % overlap:
-		
+
 			#Now check for overlaps:
 			$overlap = Bio::Rfam::Utils::overlap_nres_or_full($s1, $e1, $s2, $e2);
 			if ($overlap != 0) {
@@ -1510,8 +1510,8 @@ sub findClanOverlaps {
 				if ($percent_ol < 0.5 || $percent_ol > 2) {
 					#print "Overlap less than 50%, skipping\n";
 					next;
-				} 
-	
+				}
+
 				my $overlap_type = $poss_overlap->{strand} eq $region->{strand} ? 'SS' : 'OS';
 				$ol++;
 				#Add the overlapping region to @overlaps:
@@ -1523,7 +1523,7 @@ sub findClanOverlaps {
 		if ($ol != 0) {
 			push @overlaps, $region;
 		}
-		
+
 		#Sort the overlaps by e value and then take the highest match as the significant match:
 		#
 		my @sorted_overlap = sort {$a->{evalue} <=> $b->{evalue}} @overlaps;
@@ -1532,28 +1532,28 @@ sub findClanOverlaps {
 				$hash->{'is_significant'} = 1;
 			} else {
 				$hash->{'is_significant'} = 0;
-				my ($start, $end) = $hash->{strand} eq 1 ? ($hash->{start}, $hash->{end}):($hash->{end}, $hash->{start}); 
+				my ($start, $end) = $hash->{strand} eq 1 ? ($hash->{start}, $hash->{end}):($hash->{end}, $hash->{start});
 				my $resultset = $rfamdb->resultset('FullRegion')->search( {rfam_acc => $hash->{family},
 																		rfamseq_acc => $hash->{rfamseq_acc},
 																		seq_start => $start,
 																		seq_end => $end,
 																		evalue_score => $hash->{evalue}
 																	})->single;
-				
-				
+
+
 				$resultset->update({is_significant => '0'});
 			}
 		#
 		#	print $OVERLAP "$hash->{rfamseq_acc}\t$hash->{start}\t$hash->{end}\t$hash->{strand}\t$hash->{evalue}\t$hash->{family}\t$hash->{type}\t$hash->{is_significant}\n";
-		}	
+		}
 		#Update counter now we've done this region:
 		$seen{$orig_acc}++;
 	}
 
-	
 
-	return $clerror;	
- 
+
+	return $clerror;
+
 }
 
 
@@ -1562,28 +1562,28 @@ sub findClanOverlaps {
 
   Title    : findExternalOverlaps()
   Incept   : finnr, Aug 5, 2013 4:08:17 PM
-  Usage    : 
-  Function : 
-  Args     : 
-  Returns  : 
-  
+  Usage    :
+  Function :
+  Args     :
+  Returns  :
+
 =cut
 
 
 sub findExternalOverlaps {
   my ($familyObj, $rfamdb, $ignore, $config, $OVERLAP) = @_;
-  
+
   _addBlackListToIgnore($ignore, $config);
-  
+
   if($config->location ne 'EBI'){
     warn "This overlap test has been written assuming you have a local database.".
          "Eventually, there needs to be a Web based overlap method\n.";
   }
-  my $error = 0; 
+  my $error = 0;
   my $currentAcc = '';
   my $regions;
   foreach my $r (sort{$a->[3] cmp $b->[3]} @{$familyObj->SCORES->regions}){
-    my ($s1, $e1, $or1) = 
+    my ($s1, $e1, $or1) =
         $r->[1] <= $r->[2] ? ($r->[1], $r->[2], 1) : ($r->[2], $r->[1], -1);
 
     if($currentAcc ne $r->[3]){
@@ -1593,7 +1593,7 @@ sub findExternalOverlaps {
     foreach my $dbReg (@$regions){
       #Does it belong to a family we want to ignore?
       next if(exists($ignore->{$dbReg->[1]}));
-      my ($s2, $e2) = 
+      my ($s2, $e2) =
         $dbReg->[4] == 1 ? ($dbReg->[2], $dbReg->[3]) : ($dbReg->[3], $dbReg->[2]);
       my $overlap = 0;
       $overlap = Bio::Rfam::Utils::overlap_nres_or_full($s1, $e1, $s2, $e2);
@@ -1609,7 +1609,7 @@ sub findExternalOverlaps {
             $dbReg->[1].":".$dbReg->[0]."/".$dbReg->[2]."-".$dbReg->[3],
             $overlap;
           print $OVERLAP $eString;
-          print STDERR $eString; 
+          print STDERR $eString;
 	  $error++;
       }
     }
@@ -1623,12 +1623,12 @@ sub findExternalOverlaps {
   Title    : findInternalOverlaps
   Incept   : finnr, Jul 31, 2013 2:28:40 PM
   Usage    : Bio::Rfam::QC::findInternalOverlaps($familyObj, $OVERLAP)
-  Function : Takes a family object and looks for overlaps within the SEED 
+  Function : Takes a family object and looks for overlaps within the SEED
            : alignment. It will report overlaps to STDERR and to the overlap
            : file.
   Args     : A Bio::Rfam::Family object, overlaps filehandle
-  Returns  : 1 on error, 0 if no overlaps are found. 
-  
+  Returns  : 1 on error, 0 if no overlaps are found.
+
 =cut
 
 sub findInternalOverlaps {
@@ -1638,7 +1638,7 @@ sub findInternalOverlaps {
   if ( !$familyObj or !$familyObj->isa('Bio::Rfam::Family') ) {
     die "Did not get passed in a Bio::Rfam::Family object\n";
   }
-  
+
   if(!$OVERLAP and ref($OVERLAP) ne 'GLOB'){
     die "Did not get passed a filehandle for reporting\n";
   }
@@ -1648,20 +1648,20 @@ sub findInternalOverlaps {
                    #we should have all NSE.
 
   for ( my $i = 0 ; $i < $familyObj->SEED->nseq - 1 ; $i++ ) {
-     $atomizedNSE[$i]  = [Bio::Rfam::Utils::nse_breakdown($familyObj->SEED->get_sqname($i))] 
+     $atomizedNSE[$i]  = [Bio::Rfam::Utils::nse_breakdown($familyObj->SEED->get_sqname($i))]
         if ( !$atomizedNSE[$i] );
     for ( my $j = $i + 1 ; $j < $familyObj->SEED->nseq ; $j++ ) {
-      $atomizedNSE[$j]  = [Bio::Rfam::Utils::nse_breakdown($familyObj->SEED->get_sqname($j))] 
+      $atomizedNSE[$j]  = [Bio::Rfam::Utils::nse_breakdown($familyObj->SEED->get_sqname($j))]
         if ( !$atomizedNSE[$j] );
       next if($atomizedNSE[$i]->[1] ne $atomizedNSE[$j]->[1]);
       # determine overlap fraction (overlap_nres_or_full() is robust to start < end or start > end)
       my $overlap = Bio::Rfam::Utils::overlap_nres_or_full(
-        $atomizedNSE[$i]->[2], 
-        $atomizedNSE[$i]->[3], 
-	$atomizedNSE[$j]->[2], 
+        $atomizedNSE[$i]->[2],
+        $atomizedNSE[$i]->[3],
+	$atomizedNSE[$j]->[2],
         $atomizedNSE[$j]->[3]);
-      
-      if($overlap != 0) { 
+
+      if($overlap != 0) {
         $overlap = 'fullOL' if ( $overlap == -1 );
         my $eString = sprintf "Internal overlap of %s with %s by %s\n",
         $familyObj->SEED->get_sqname($i),
@@ -1682,27 +1682,27 @@ sub findInternalOverlaps {
   Title    : codingSeqs
   Incept   : finnr, Jul 29, 2013 3:10:48 PM
   Usage    : Bio::Rfam::QC::codingSeqs($familyObj, $config)
-  Function : Takes the seed alignment, reformats it to clustal (with '-' as a 
+  Function : Takes the seed alignment, reformats it to clustal (with '-' as a
            : gap character). It then runs third party software, RNACode to
-           : identify potential coding regions. The p-value threshold for this 
+           : identify potential coding regions. The p-value threshold for this
            : comes from the config.
   Args     : A Bio::Rfam::Family object, a Bio::Rfam::Config
   Returns  : 0 when no errors, 1 and scalar of RNAcode output on error.
-  
+
 =cut
 
 sub codingSeqs {
   my ($familyObj, $config) = @_;
-  
+
   my ($fh, $filename) = tempfile();
   close($fh);
 
   #Write the file out as clustal
   $familyObj->SEED->write_msa($filename, 'clustal');
-    
+
   #Get the pvalue that we will use for cut-off.
   my $pvalue = $config->rnacode_pvalue; #Get via the config.
-  
+
   #run RNAcode on clustal file and capture results in STDOUT pipe.
   my @cmd = qw(RNAcode -s -p );
   push(@cmd, $pvalue, $filename);
@@ -1727,47 +1727,47 @@ sub codingSeqs {
   Usage    : Bio::Rfam::QC::essential($newFamilyObj, $dir, $oldFamily, $config)
   Function : Takes the new family and performs all of the essential QC steps on
            : the family. Due to the repetoire of QC, need file location, old family
-           : and config objects. 
+           : and config objects.
   Args     : Bio::Rfam::Family object for the new family,
            : path to the family,
            : Bio::Rfam::Family object for the old family or undef if new,
            : A Bio::Rfam::Config object
   Returns  : 1 on error, 0 on success.
-  
+
 =cut
 
 sub essential {
-  my ($newFamily, $dir, $oldFamily, $config) = @_; 
+  my ($newFamily, $dir, $oldFamily, $config) = @_;
 
   my $masterError = 0;
   my $error = 0;
-  
+
   my $seqDBObj = $config->rfamseqObj;
-  
+
   $error = Bio::Rfam::QC::checkTimestamps($dir, $config);
   if($error){
     warn "Family failed essential format checks.\n";
     $masterError = 1;
   }
-  
+
   $error = Bio::Rfam::QC::checkFamilyFormat($newFamily);
   if($error){
     warn "Family failed essential format checks.\n";
     $masterError = 1;
   }
-  
+
   $error = checkSEEDSeqs($newFamily, $seqDBObj);
   if($error){
     warn "Family failed essential check that seed sequences are all valid (from at least one of rfamseq, GenBank or RNAcentral).\n";
     $masterError = 1;
   }
-  
+
   $error = checkScoresSeqs($newFamily, $seqDBObj);
   if($error){
     warn "Family failed essential threshold check.\n";
     $masterError = 1;
   }
-  
+
   if(defined($oldFamily)){
     $error = checkFixedFields($newFamily, $oldFamily);
     if($error){
@@ -1775,7 +1775,7 @@ sub essential {
       $masterError = 1;
     }
   }
-  
+
   open( my $OVERLAP, '>>', "$dir/overlap") or die "Could not open $dir/overlap:[$!]";
   $error = findInternalOverlaps($newFamily, $OVERLAP);
   close($OVERLAP);
@@ -1783,12 +1783,12 @@ sub essential {
     warn "Found internal SEED overlaps.\n";
     $masterError = 1;
   }
-  
+
   return( $masterError );
 }
 
 #------------------------------------------------------------------------------
-=head2 
+=head2
 
   Title    : optional
   Incept   : finnr, Aug 5, 2013 3:55:47 PM
@@ -1810,7 +1810,7 @@ sub optional {
   my $error       = 0;
   my $masterError = 0;
   my $msg         = "";
-  
+
   if(!exists($override->{spell})){
     $error = checkSpell($dir, $config->dictionary);
     if($error){
@@ -1820,7 +1820,7 @@ sub optional {
   }else{
     warn "Ignoring spell check.\n";
   }
- 
+
   if(!exists($override->{seed})){
     $error = compareSeedAndSeedScores($newFamily);
     if($error){
@@ -1830,7 +1830,7 @@ sub optional {
   }else{
     warn "Ignoring check to ensure all SEED sequences found.\n";
   }
-  
+
   if(!exists($override->{coding})){
     ($error, $msg) = codingSeqs($newFamily, $config);
     if($error){
@@ -1852,13 +1852,13 @@ sub optional {
           #Override the error....
           $error = 0;
         }
-        else { 
+        else {
           $masterError = 1;
         }
       }
     }
   }
-  
+
   #Okay, hack time; allow overlaps....for some families
   if(!exists($override->{overlap})){
     open( my $OVERLAP, '>>', "$dir/overlap") or die "Could not open $dir/overlap:[$!]";
@@ -1871,7 +1871,7 @@ sub optional {
    }else{
     warn "Ignoring overlap check.\n";
   }
-  
+
   return($masterError);
 }
 
@@ -1888,12 +1888,12 @@ sub optional {
            : families, the overlap option will not be run.
   Args     : Array containing options, Bio::Rfam::Config object, accession of family (optional)
   Returns  : hash, keys are allowed options.
-  
+
 =cut
 
 sub processIgnoreOpt {
   my ($ignoreRef, $config, $acc) = @_;
-  
+
   #See if the family if one of the few blacklisted? If so,
   #do not bother running the overlap check.
   if($acc){
@@ -1902,9 +1902,9 @@ sub processIgnoreOpt {
 	  push (@$ignoreRef, 'overlap');
 	}
   }
-  
+
   my $allowedOpts = $config->ignorableQC;
- 
+
   #Go through each option passed in and see if it is allowed.
   foreach my $i (@{$ignoreRef}){
     if(! exists($allowedOpts->{$i})){
@@ -1917,19 +1917,19 @@ sub processIgnoreOpt {
 }
 
 sub essentialClan {
-  my ($newClan, $oldClan, $config) = @_; 
+  my ($newClan, $oldClan, $config) = @_;
 
   my $masterError = 0;
   my $error = 0;
-  
+
   $error = Bio::Rfam::QC::checkClanFormat($newClan);
-  
+
   if($error){
     warn "Family failed essential clan format checks.\n";
     $masterError = 1;
   }
-  
-  
+
+
   if(defined($oldClan)){
     $error = checkClanFixedFields( $newClan, $oldClan );
     if($error){
@@ -1937,22 +1937,22 @@ sub essentialClan {
       $masterError = 1;
     }
   }
-  
+
   return $masterError;
 }
 
 
 sub checkClanFormat {
   my ($clanObj) = @_;
-  
+
   my $error = 0;
    #Make sure none of the default values set in writeEmptyDESC still exist
-  foreach my $key ( keys %{ $clanObj->DESC->defaultButIllegalFields } ) { 
+  foreach my $key ( keys %{ $clanObj->DESC->defaultButIllegalFields } ) {
     if ( !defined( $clanObj->DESC->$key ) ) { #make sure it's defined first
       warn "Required CLANDESC field $key not defined.\n";
       $error++;
     }
-    elsif( $clanObj->DESC->$key eq $clanObj->DESC->defaultButIllegalFields->{$key} ) { 
+    elsif( $clanObj->DESC->$key eq $clanObj->DESC->defaultButIllegalFields->{$key} ) {
       warn "CLANDESC field $key illegal value (appears unchanged from default).\n";
       $error++;
     }
@@ -1967,7 +1967,7 @@ sub optionalClan{
   my $error       = 0;
   my $masterError = 0;
   my $msg         = "";
-  
+
   if(!exists($override->{spell})){
     $error = checkSpell($dir, $config->dictionary);
     if($error){
@@ -1976,7 +1976,7 @@ sub optionalClan{
     }
   }else{
     warn "Ignoring spell check.\n";
-  } 
+  }
 }
 #------------------------------------------------------------------------------
 =head2 _addBlackListToIgnore
@@ -1988,16 +1988,16 @@ sub optionalClan{
            : families.
   Args     : hash reference, Bio::Rfam::Config object.
   Returns  : Nothing - hash reference is manipulated.
-  
+
 =cut
 
 sub _addBlackListToIgnore {
   my ($ignore, $config) = @_;
-  
+
   foreach my $k (keys( %{ $config->allowedOverlaps })){
     $ignore->{$k} = 1;
   }
-  
+
   return;
 }
 

--- a/Rfam/Lib/Bio/Rfam/QC.pm
+++ b/Rfam/Lib/Bio/Rfam/QC.pm
@@ -1163,7 +1163,7 @@ sub checkSEEDSeqs_helper {
 
     # lookup in RNAcentral
     my ($rnacentral_has_exact_seq, $rnacentral_md5, $rnacentral_id, undef) = Bio::Rfam::Utils::rnacentral_md5_lookup($seed_md5);
-
+    my ($rnacentral_has_exact_subseq) = Bio::Rfam::Utils::rnacentral_subseq_lookup($nse, $seed_md5);
     #
     my $pass_rfm = 0;
     my $pass_gbk = 0;
@@ -1187,7 +1187,7 @@ sub checkSEEDSeqs_helper {
       if($be_verbose) { $outstr .= "NOT-NAME/START-END"; }
       else            { warn "SEED sequence $nse fails validation; it is not in valid name/start-end format\n"; }
     }
-    if((! $rfamseq_has_source_seq) && (! $genbank_has_source_seq) && (! $rnacentral_has_exact_seq)) {
+    if((! $rfamseq_has_source_seq) && (! $genbank_has_source_seq) && (! $rnacentral_has_exact_seq) && (! $rnacentral_has_exact_subseq)) {
       # 2) not in any of Rfamseq, GenBank, or RNAcentral
       $passfail = "FAIL";
       if($be_verbose) { $outstr .= "NO-MATCHES"; }
@@ -1231,7 +1231,9 @@ sub checkSEEDSeqs_helper {
         if($be_verbose) { $outstr .= "GBK:md5-pass;"; }
       }
     }
-    if($rnacentral_has_exact_seq) {
+    if($rnacentral_has_exact_subseq) {
+      $nrnc_pass += 1;
+    } elsif($rnacentral_has_exact_seq) {
       if($rnacentral_md5 ne $seed_md5) {
         # 7) subseq appears to exist in RNAcentral, but md5 does not match
         #    (THIS SHOULD BE IMPOSSIBLE BECAUSE WE LOOK UP IN RNACENTRAL BASED ON md5)

--- a/Rfam/Lib/Bio/Rfam/Utils.pm
+++ b/Rfam/Lib/Bio/Rfam/Utils.pm
@@ -12,8 +12,8 @@ use File::Spec;
 use Carp;
 
 use Digest::MD5 qw(md5_hex);
-use LWP::Simple;                
-use JSON qw( decode_json );     
+use LWP::Simple;
+use JSON qw( decode_json );
 use XML::LibXML;
 use Time::HiRes qw(usleep);
 
@@ -44,9 +44,9 @@ our $FASTATEXTW = '60';    # 60 characters per line in FASTA seq output
 
 =cut
 
-sub run_local_command { 
+sub run_local_command {
   my ($cmd) = @_;
-  
+
   system($cmd);
   if($? != 0) { croak "$cmd failed"; }
   return;
@@ -76,23 +76,23 @@ sub run_local_command {
 
 =cut
 
-sub submit_nonmpi_job { 
+sub submit_nonmpi_job {
   my ($location, $cmd, $jobname, $errPath, $ncpu, $reqMb, $exStr, $queue) = @_;
 
   my $submit_cmd = "";
   if(defined $queue && $queue eq "p") { $queue = "production-rh74"; }
   if(defined $queue && $queue eq "r") { $queue = "research-rh74"; }
 
-  if($location eq "EBI") { 
+  if($location eq "EBI") {
     if(! defined $ncpu)  { die "submit_nonmpi_job(), location is EBI, but ncpu is undefined"; }
     if(! defined $reqMb) { die "submit_nonmpi_job(), location is EBI, but reqMb is undefined"; }
     $submit_cmd = "bsub ";
     if(defined $exStr && $exStr ne "") { $submit_cmd .= "$exStr "; }
-    if(defined $queue && $queue ne "") { 
-      $submit_cmd .= "-q $queue "; 
+    if(defined $queue && $queue ne "") {
+      $submit_cmd .= "-q $queue ";
     }
-    else { 
-      $submit_cmd .= "-q research-rh74 "; 
+    else {
+      $submit_cmd .= "-q research-rh74 ";
     }
     $submit_cmd .= "-n $ncpu -J $jobname -o /dev/null -e $errPath -M $reqMb -R \"rusage[mem=$reqMb]\" \"$cmd\" > /dev/null";
   }
@@ -105,7 +105,7 @@ sub submit_nonmpi_job {
 #    }
     $submit_cmd = "/Rfam/software/bin/rfkubesub.py \"$cmd\" $ncpu $reqMb $jobname";
   }
-  elsif($location eq "JFRC") { 
+  elsif($location eq "JFRC") {
     my $batch_opt = "";
     if(defined $ncpu && $ncpu > 1) { $batch_opt = "-pe batch $ncpu"; }
     $submit_cmd = "qsub ";
@@ -114,13 +114,13 @@ sub submit_nonmpi_job {
     if(defined $queue && $queue ne "") { $submit_cmd .= "-l $queue=true "; }
 #    else                               { $submit_cmd .= "-q new.q "; }
     else                               { $submit_cmd .= ""; }
-    $submit_cmd .= " -N $jobname -o /dev/null -e $errPath $batch_opt -b y -cwd -V \"$cmd\" > /dev/null"; 
+    $submit_cmd .= " -N $jobname -o /dev/null -e $errPath $batch_opt -b y -cwd -V \"$cmd\" > /dev/null";
   }
   # local command
   elsif($location eq ""){
     $submit_cmd = $cmd
   }
-  else { 
+  else {
     die "ERROR unknown location $location in submit_nonmpi_job()";
   }
 
@@ -154,11 +154,11 @@ sub submit_nonmpi_job {
 
 =cut
 
-sub submit_mpi_job { 
+sub submit_mpi_job {
   my ($location, $cmd, $jobname, $errPath, $nproc, $queue) = @_;
 
   my $submit_cmd = "";
-  if($location eq "EBI") { 
+  if($location eq "EBI") {
     # EPN: for some reason, this 'module' command fails inside perl..., I think it may be unnecessary because it's in my .bashrc
     #my $prepcmd = "module load openmpi-x86_64";
     #system($prepcmd);
@@ -171,7 +171,7 @@ sub submit_mpi_job {
     # ORIGINAL COMMAND (I BELIEVE WE WILL REVERT TO THIS EVENTUALLY):
     # $submit_cmd = "bsub -J $jobname -e $errPath -q mpi -I -n $nproc -a openmpi mpirun.lsf -np $nproc -mca btl tcp,self $cmd";
   }
-  elsif($location eq "JFRC") { 
+  elsif($location eq "JFRC") {
     my $queue_opt = "";
     if($queue ne "") { $queue_opt = "-l $queue=true "; }
     $submit_cmd = "qsub -N $jobname -e $errPath -o /dev/null -b y -cwd -V -pe impi $nproc " . $queue_opt . "\"mpirun -np $nproc $cmd\" > /dev/null";
@@ -179,7 +179,7 @@ sub submit_mpi_job {
   elsif ($location eq "CLOUD"){
   	die "ERROR: MPI unavailable on CLOUD. Consider using -cnompi option";
   }
-  else { 
+  else {
     die "ERROR unknown location $location in submit_mpi_job()";
   }
 
@@ -199,27 +199,27 @@ sub submit_mpi_job {
     Incept   : EPN, Sat Mar 30 07:01:24 2013
     Usage    : wait_for_cluster($jobnameAR, $outnameAR, $success_string, $program, $outFH, $max_minutes)
     Function : Waits for specific job(s) to finish running on cluster
-             : and verifies their output. 
+             : and verifies their output.
              : The job names are listed in $jobnameAR. Each
              : job will produce an output file named $outnameAR. When
              : each job finishes, as indicated by it no longer appearing
              : in a list of queued or running jobs on the cluster, we
              : check that (a) its output file exists and (b) its output
              : file includes the string $success_string. If $max_minutes
-             : is defined and != -1, we will die if all jobs fail to 
-             : successfully complete within $max_minutes minutes. 
+             : is defined and != -1, we will die if all jobs fail to
+             : successfully complete within $max_minutes minutes.
              :
              : See an alternative function that serves the same purpose:
              : 'wait_for_cluster_light' but that uses the expensive
              : 'qstat' or 'bjobs' calls less frequently.
-             : 
+             :
              : Ways to return or die:
-             : (1) Returns if all jobs finish and all jobs output files 
-             :     contain $success_string string. This is only way to 
+             : (1) Returns if all jobs finish and all jobs output files
+             :     contain $success_string string. This is only way to
              :     return successfully.
-             : (2) Dies if $success_string ne "" and any job finishes 
+             : (2) Dies if $success_string ne "" and any job finishes
              :     and its output file does not contain at least 1 line
-             :     that *begins with* $success_string. 
+             :     that *begins with* $success_string.
              : (3) Dies if $max_minutes is defined and != -1, and any
              :     job takes longer than $max_minutes to complete.
              :
@@ -227,24 +227,24 @@ sub submit_mpi_job {
              : $username:       username the cluster jobs belong to
              : $jobnameAR:      ref to array of list of job names on cluster
              : $outnameAR:      ref to array of list of output file names, one per job
-             : $success_string: string expected to exist in each output file 
+             : $success_string: string expected to exist in each output file
              : $program:        name of program running, if "": do not print updates
              : $outFH:          output file handle for updates, if "" only print to STDOUT
              : $extra_note:     extra information to output with progress, "" for none
              : $max_minutes:    max number of minutes to wait, -1 for no limit
              : $do_stdout:      1 to print updates to stdout, 0 not to
              :
-    Returns  : Maximum number of seconds any job spent waiting in queue, rounded down to 
+    Returns  : Maximum number of seconds any job spent waiting in queue, rounded down to
              : nearest 10 seconds.
     Dies     : Cases (2) or (3) listed in "Function" section above.
 
 =cut
 
-sub wait_for_cluster { 
+sub wait_for_cluster {
   my ($location, $username, $jobnameAR, $outnameAR, $success_string, $program, $outFH, $extra_note, $max_minutes, $do_stdout) = @_;
 
   my $start_time = time();
-  
+
   my $n = scalar(@{$jobnameAR});
   my $i;
   if($extra_note ne "") { $extra_note = "  " . $extra_note; }
@@ -253,18 +253,18 @@ sub wait_for_cluster {
   if(scalar(@{$outnameAR}) != $n) { die "wait_for_cluster(), internal error, number of elements in jobnameAR and outnameAR differ"; }
 
   # modify username > 7 characters and job names > 10 characters if we're at EBI, because bjobs truncates these
-  if($location eq "EBI") { 
-    if(length($username) > 7) { 
+  if($location eq "EBI") {
+    if(length($username) > 7) {
       $username = substr($username, 0, 7); # bjobs at EBI only prints first 7 letters of username
     }
-    for($i = 0; $i < $n; $i++) { 
-      if(length($jobnameAR->[$i]) > 10) { # NOTE: THIS WILL CHANGE THE VALUES IN THE ACTUAL ARRAY jobnameAR POINTS TO!
+    for($i = 0; $i < $n; $i++) {
+      if(length($jobnameAR->[$i]) > 10) { # NOTE: THIS WILL CHANGE THE VALUES IN THE ACTUAL ARRAY jobnameAR POINTS TO
         $jobnameAR->[$i] = "*" . substr($jobnameAR->[$i], -9);
       }
     }
   }
-  elsif($location ne "JFRC") { 
-    die "ERROR in wait_for_cluster, unrecognized location: $location"; 
+  elsif($location ne "JFRC") {
+    die "ERROR in wait_for_cluster, unrecognized location: $location";
   }
 
   my $sleep_nsecs = 60;  # we'll call qstat/bjobs every 5 seconds
@@ -277,29 +277,29 @@ sub wait_for_cluster {
   my $max_wait_secs = 0;
   my ($minutes_elapsed, $nrunning, $nwaiting, $line, $uname, $jobname, $status, $i2);
   $i2 = 0;
-  for($i = 0; $i < $n; $i++) { $successA[$i] = 0; } 
+  for($i = 0; $i < $n; $i++) { $successA[$i] = 0; }
 
-  sleep(2); 
+  sleep(2);
 
-  while($nsuccess != $n) { 
+  while($nsuccess != $n) {
     if   ($location eq "JFRC") { @infoA = split("\n", `qstat`); }
     elsif($location eq "EBI")  { @infoA = split("\n", `bjobs`); }
 
-    for($i = 0; $i < $n; $i++) { $ininfoA[$i] = 0; } 
+    for($i = 0; $i < $n; $i++) { $ininfoA[$i] = 0; }
     $nrunning  = 0;
     $nwaiting  = 0;
-    foreach $line (@infoA) { 
-      if($line =~ m/^\s*\d+\s+/) { 
+    foreach $line (@infoA) {
+      if($line =~ m/^\s*\d+\s+/) {
         $line =~ s/^\s*//;
         @elA = split(/\s+/, $line);
-        if($location eq "JFRC") { 
-          #1232075 4.79167 QLOGIN     davisf       r     03/25/2013 14:24:11 f02.q@f02u09.int.janelia.org                                      8        
-          # 396183 10.25000 QLOGIN     nawrockie    r     07/26/2013 10:10:41 new.q@h02u19.int.janelia.org                                      1        
-          # 565685 0.00000 c.25858    nawrockie    qw    08/01/2013 15:18:55                                                                  81        
+        if($location eq "JFRC") {
+          #1232075 4.79167 QLOGIN     davisf       r     03/25/2013 14:24:11 f02.q@f02u09.int.janelia.org                                      8
+          # 396183 10.25000 QLOGIN     nawrockie    r     07/26/2013 10:10:41 new.q@h02u19.int.janelia.org                                      1
+          # 565685 0.00000 c.25858    nawrockie    qw    08/01/2013 15:18:55                                                                  81
           ($jobname, $uname, $status) = ($elA[2], $elA[3], $elA[4]);
         }
-        elsif($location eq "EBI") { 
-          # jobid   uname   status queue     sub node    run node    job name   date     
+        elsif($location eq "EBI") {
+          # jobid   uname   status queue     sub node    run node    job name   date
           # 5134531 vitor   RUN   research-r ebi-004     ebi5-037    *lection.R Apr 29 18:00
           # 4422939 stauch  PEND  research-r ebi-001                 *ay[16992] Apr 26 12:56
           ($uname, $status) = ($elA[1], $elA[2]);
@@ -310,38 +310,38 @@ sub wait_for_cluster {
         #printf("\tjobname: $jobname uname: $uname status: $status\n");
         if($uname ne $username) { die "wait_for_cluster(), internal error, uname mismatch ($uname ne $username)"; }
         # look through our list of jobs and see if this one matches
-        for($i = 0; $i < $n; $i++) { 
+        for($i = 0; $i < $n; $i++) {
           #printf("\t\tsuccess: %d\tininfo: %d\tmatch: %d\n", $successA[$i], $ininfoA[$i], ($jobnameAR->[$i] eq $jobname) ? 1 : 0);
-          if((! $successA[$i]) &&              # job didn't successfully complete already 
+          if((! $successA[$i]) &&              # job didn't successfully complete already
              (! $ininfoA[$i]) &&              # we didn't already find this job in the queue
              ($jobnameAR->[$i] eq $jobname)) { # jobname match
-            $ininfoA[$i] = 1; 
-            if($location eq "JFRC") { 
+            $ininfoA[$i] = 1;
+            if($location eq "JFRC") {
               if($status eq "r")     { $nrunning++; }
               elsif($status =~ m/E/) { die "wait_for_cluster(), internal error, qstat shows Error status: $line"; }
-              else                   { $nwaiting++; } 
+              else                   { $nwaiting++; }
             }
-            elsif($location eq "EBI") { 
+            elsif($location eq "EBI") {
               if   ($status eq "RUN")  { $nrunning++; }
-              elsif($status eq "PEND") { $nwaiting++; } 
+              elsif($status eq "PEND") { $nwaiting++; }
               else                     { die "wait_for_cluster(), internal error, bjobs shows non-\"RUN\" and non-\"PEND\" status: $line"; }
             }
           }
         }
-      } # end of if($line =~ m/^\d/) 
+      } # end of if($line =~ m/^\d/)
     } # end of 'foreach $line (@infoA)'
-    if($nwaiting > 0) { $max_wait_secs = time() - $start_time; } 
+    if($nwaiting > 0) { $max_wait_secs = time() - $start_time; }
 
     # for all jobs not found in the qstat output, make sure they finished properly
-    for($i = 0; $i < $n; $i++) { 
-      if((! $successA[$i]) && # job didn't successfully complete already 
+    for($i = 0; $i < $n; $i++) {
+      if((! $successA[$i]) && # job didn't successfully complete already
          (! $ininfoA[$i])) { # we didn't find this job in the queue
         if(! -e $outnameAR->[$i]) { die "wait_for_cluster() job $i seems to be finished (not in queue) but expected output file ($outnameAR->[$i] does not exist"; }
-        open(IN, $outnameAR->[$i]) || die "wait_for_cluster() job $i seems to be finished (not in queue) but expected output file ($outnameAR->[$i] can't be opened"; 
-        while($line = <IN>) { 
+        open(IN, $outnameAR->[$i]) || die "wait_for_cluster() job $i seems to be finished (not in queue) but expected output file ($outnameAR->[$i] can't be opened";
+        while($line = <IN>) {
           if($line =~ m/\Q$success_string/) {
-            $successA[$i] = 1; 
-            $nsuccess++; 
+            $successA[$i] = 1;
+            $nsuccess++;
             #printf("\tjob %2d finished successfully!\n", $i);
             last;
           }
@@ -351,10 +351,10 @@ sub wait_for_cluster {
       }
     }
     $minutes_elapsed = (time() - $start_time) / 60;
-    if($program ne "") { 
-      if($nsuccess == $n || $i2 % $print_freq == 0) { 
+    if($program ne "") {
+      if($nsuccess == $n || $i2 % $print_freq == 0) {
         my $outstr = sprintf("  %-15s  %-10s  %10s  %10s  %10s  %10s%s\n", $program, "cluster", $nsuccess, $nrunning, $nwaiting, Bio::Rfam::Utils::format_time_string(time() - $start_time), $extra_note);
-        $extra_note = ""; # only print this once 
+        $extra_note = ""; # only print this once
         if($do_stdout) { print STDOUT $outstr; }
         if($outFH ne "") { print $outFH $outstr; }
       }
@@ -363,9 +363,9 @@ sub wait_for_cluster {
     if(defined $max_minutes && $max_minutes != -1 && $minutes_elapsed > $max_minutes) { die "wait_for_cluster(), reached maximum time limit of $max_minutes minutes, exiting."; }
     if($nsuccess != $n) { sleep($sleep_nsecs); }
   }
-  
+
   return $max_wait_secs;
-  # The only way we'll get here is if all jobs are finished (not in queue) 
+  # The only way we'll get here is if all jobs are finished (not in queue)
   # and have $success_string in output file, if not, we'll have die'd earlier
 }
 
@@ -377,10 +377,10 @@ sub wait_for_cluster {
     Incept   : EPN, Sat Mar 30 07:01:24 2013
     Usage    : wait_for_cluster_light($jobnameAR, $outnameAR, $success_string, $program, $outFH, $max_minutes)
     Function : Waits for specific job(s) to finish running on cluster
-             : and verifies their output. 
+             : and verifies their output.
              : The job names are listed in $jobnameAR. Each
              : job will produce an output file listed in @{$outnameAR}
-             : and an stderr error file listed in @{$errnameAR}. 
+             : and an stderr error file listed in @{$errnameAR}.
              : This function (the '_light' version) determines which jobs
              : are finished mostly using the existence of error files and
              : by looking for the success string in those error files
@@ -388,16 +388,16 @@ sub wait_for_cluster {
              : The non-light version (wait_for_cluster()) calls 'qstat'/'bjobs'
              : once every minute.
              :
-             : If $max_minutes is defined and != -1, we will die if all jobs 
-             : fail to successfully complete within $max_minutes minutes. 
-             : 
+             : If $max_minutes is defined and != -1, we will die if all jobs
+             : fail to successfully complete within $max_minutes minutes.
+             :
              : Ways to return or die:
-             : (1) Returns if all jobs finish and all jobs output files 
-             :     contain $success_string string. This is only way to 
+             : (1) Returns if all jobs finish and all jobs output files
+             :     contain $success_string string. This is only way to
              :     return successfully.
-             : (2) Dies if $success_string ne "" and any job finishes 
+             : (2) Dies if $success_string ne "" and any job finishes
              :     and its output file does not contain at least 1 line
-             :     that *begins with* $success_string. 
+             :     that *begins with* $success_string.
              : (3) Dies if $max_minutes is defined and != -1, and any
              :     job takes longer than $max_minutes to complete.
              :
@@ -406,20 +406,20 @@ sub wait_for_cluster {
              : $jobnameAR:      ref to array of list of job names on cluster
              : $outnameAR:      ref to array of list of output file names, one per job
              : $errnameAR:      ref to array of list of err file names, one per job
-             : $success_string: string expected to exist in each output file 
+             : $success_string: string expected to exist in each output file
              : $program:        name of program running, if "": do not print updates
              : $outFH:          output file handle for updates, if "" only print to STDOUT
              : $extra_note:     extra information to output with progress, "" for none
              : $max_minutes:    max number of minutes to wait, -1 for no limit
              : $do_stdout:      1 to print updates to stdout, 0 not to
              :
-    Returns  : Maximum number of seconds any job spent waiting in queue, rounded down to 
+    Returns  : Maximum number of seconds any job spent waiting in queue, rounded down to
              : nearest 10 seconds.
     Dies     : Cases (2) or (3) listed in "Function" section above.
 
 =cut
 
-sub wait_for_cluster_light { 
+sub wait_for_cluster_light {
   my ($location, $username, $jobnameAR, $outnameAR, $errnameAR, $success_string, $program, $outFH, $extra_note, $max_minutes, $do_stdout) = @_;
 
   my $start_time = time();
@@ -428,23 +428,23 @@ sub wait_for_cluster_light {
   if($extra_note ne "") { $extra_note = "  " . $extra_note; }
 
   # sanity check - limit this to EBI and JFRC clusters only
-  
+
   if(scalar(@{$outnameAR}) != $n) { die "wait_for_cluster_light(), internal error, number of elements in jobnameAR and outnameAR differ"; }
   if(scalar(@{$errnameAR}) != $n) { die "wait_for_cluster_light(), internal error, number of elements in jobnameAR and errnameAR differ"; }
-  
+
   # modify username > 7 characters and job names > 10 characters if we're at EBI, because bjobs truncates these
-  if($location eq "EBI") { 
-    if(length($username) > 7) { 
+  if($location eq "EBI") {
+    if(length($username) > 7) {
       $username = substr($username, 0, 7); # bjobs at EBI only prints first 7 letters of username
     }
-    for($i = 0; $i < $n; $i++) { 
+    for($i = 0; $i < $n; $i++) {
       if(length($jobnameAR->[$i]) > 10) { # NOTE: THIS WILL CHANGE THE VALUES IN THE ACTUAL ARRAY jobnameAR POINTS TO!
         $jobnameAR->[$i] = "*" . substr($jobnameAR->[$i], -9);
       }
     }
   }
-  elsif(($location ne "JFRC") && ($location ne "CLOUD")) { 
-    die "ERROR in wait_for_cluster_light, unrecognized location: $location"; 
+  elsif(($location ne "JFRC") && ($location ne "CLOUD")) {
+    die "ERROR in wait_for_cluster_light, unrecognized location: $location";
   }
 
   my $sleep_nsecs = 30;  # we'll look at file system every 30 seconds
@@ -465,9 +465,9 @@ sub wait_for_cluster_light {
   my @runningA  = ();  # [0..$n-1]: '1' if job is running (its error file does exist), else '0'
   my @waitingA  = ();  # [0..$n-1]: '1' if job is waiting (its error does not exists), else '0'
   my @finishedA  = (); # [0..$n-1]: '1' if job does not exist in the queue and so should be finished (revealed by 'qstat' or 'bjobs'), else '0'
-  
+
   # initialize status buffers
-  for($i = 0; $i < $n; $i++) { 
+  for($i = 0; $i < $n; $i++) {
     $finishedA[$i] = 0;
     $successA[$i] = 0;
     $runningA[$i] = 0;
@@ -478,22 +478,22 @@ sub wait_for_cluster_light {
   my $nsuccess = 0;
   my $nrunning = 0;
   my $nwaiting = $n;
-  
-  while($nsuccess != $n) { 
+
+  while($nsuccess != $n) {
     # determine if we should check the cluster using 'qstat/bjobs' to determine
     # which jobs are no longer in the queue, these should've all finished
     # successfully
     $do_cluster_check = 0;
     if((($ncycle == $ncycle_thresh) && ($nrunning > 0)) || # we've reached the threshold of number of times to wait before checking cluster and at least some jobs are not waiting, do it
        (($ncluster_check == 0) && ($ncycle > 0) && ($nwaiting == 0))) # we haven't checked the cluster at all yet, and all jobs appear to be running, do it
-    { 
+    {
       $do_cluster_check = 1;
     }
 
     #################################################
     # CLUSTER CHECK BLOCK
     #
-    if($do_cluster_check) { 
+    if($do_cluster_check) {
       #printf("checking the cluster with qstat/bjobs\n");
       sleep(rand(30)); # randomize wait time here, so all jobs started at same time don't run qstat/bjobs at exact same time
       $ncycle = 0; # reset to 0
@@ -501,26 +501,26 @@ sub wait_for_cluster_light {
       if   ($location eq "JFRC") { @infoA = split("\n", `qstat`); }
       elsif($location eq "EBI")  { @infoA = split("\n", `bjobs`); }
       # Fetch all running jobs of a specific user
-      elsif($location eq "CLOUD") { @infoA = split("\n", `kubectl get pods --selector=user=$username --selector=tier=backend`);} 
-      
+      elsif($location eq "CLOUD") { @infoA = split("\n", `kubectl get pods --selector=user=$username --selector=tier=backend`);}
+
       # initialize array
-      for($i = 0; $i < $n; $i++) { $ininfoA[$i] = 0; } 
-      
+      for($i = 0; $i < $n; $i++) { $ininfoA[$i] = 0; }
+
       # parse job log
       foreach $line (@infoA) {
         if ($location ne "CLOUD"){
-        if($line =~ m/^\s*\d+\s+/) {   
+        if($line =~ m/^\s*\d+\s+/) {
           $line =~ s/^\s*//;
           @elA = split(/\s+/, $line);
-          if($location eq "JFRC") { 
-            #1232075 4.79167 QLOGIN     davisf       r     03/25/2013 14:24:11 f02.q@f02u09.int.janelia.org                                      8        
-            # 396183 10.25000 QLOGIN     nawrockie    r     07/26/2013 10:10:41 new.q@h02u19.int.janelia.org                                      1        
-            # 565685 0.00000 c.25858    nawrockie    qw    08/01/2013 15:18:55                                                                  81        
+          if($location eq "JFRC") {
+            #1232075 4.79167 QLOGIN     davisf       r     03/25/2013 14:24:11 f02.q@f02u09.int.janelia.org                                      8
+            # 396183 10.25000 QLOGIN     nawrockie    r     07/26/2013 10:10:41 new.q@h02u19.int.janelia.org                                      1
+            # 565685 0.00000 c.25858    nawrockie    qw    08/01/2013 15:18:55                                                                  81
             ($jobname, $uname, $status) = ($elA[2], $elA[3], $elA[4]);
           } # closes JFRC if
 
-          elsif($location eq "EBI") { 
-            # jobid   uname   status queue     sub node    run node    job name   date     
+          elsif($location eq "EBI") {
+            # jobid   uname   status queue     sub node    run node    job name   date
             # 5134531 vitor   RUN   research-r ebi-004     ebi5-037    *lection.R Apr 29 18:00
             # 4422939 stauch  PEND  research-r ebi-001                 *ay[16992] Apr 26 12:56
             ($uname, $status) = ($elA[1], $elA[2]);
@@ -528,29 +528,29 @@ sub wait_for_cluster_light {
             else                 { $jobname = $elA[5]; }
             #print STDERR ("uname: $uname status: $status; jobname: $jobname\n");
           } # closes EBI if
-          
-          # no need to do this for CLOUD 
+
+          # no need to do this for CLOUD
           if($uname ne $username) { die "wait_for_cluster_light(), internal error, uname mismatch ($uname ne $username)"; }
-          
+
           # look through our list of jobs and see if this one matches
           for($i = 0; $i < $n; $i++) { #5
             #printf("\t\tsuccess: %d\tininfo: %d\tmatch: %d\n", $successA[$i], $ininfoA[$i], ($jobnameAR->[$i] eq $jobname) ? 1 : 0);
-              if((! $successA[$i]) &&              # job didn't successfully complete already 
+              if((! $successA[$i]) &&              # job didn't successfully complete already
                  (! $ininfoA[$i]) &&               # we didn't already find this job in the queue
                  ($jobnameAR->[$i] eq $jobname)) { # jobname match
-                  $ininfoA[$i] = 1; 
+                  $ininfoA[$i] = 1;
                   $i = $n;
-                  
+
                   if (($location eq "JFRC") && ($status =~ m/E/))                       { die "wait_for_cluster_light(), internal error, qstat shows Error status: $line"; }
                   if (($location eq "EBI")  && ($status ne "RUN" && $status ne "PEND")) { die "wait_for_cluster_light(), internal error, bjobs shows non-\"RUN\" and non-\"PEND\" status: $line"; }
               }
           } # EBI/JFRC for loop
         } # first line check here
       } # EBI/JFRC location if
-      
+
       # CHECK THE JOBS RUNNING ON THE CLOUD
       else{
-	      
+
           $line =~ s/^\s*//;
           @elA = split(/\s+/, $line);
 	  # example of kubectl get output
@@ -561,10 +561,10 @@ sub wait_for_cluster_light {
           # rfsearch-job-root-hzc28                         0/1     ContainerCreating   0          19m
 
           ($jobname, $status) = ($elA[0], $elA[2]);
-          
+
 	  # check if any of the running jobs matches those in the job array
           for($i = 0; $i < $n; $i++) { #5 - TODO: jobnameAR needs to be converted into a dictionary for faster processing
-            if((! $successA[$i]) &&              # job didn't successfully complete already 
+            if((! $successA[$i]) &&              # job didn't successfully complete already
                  (! $ininfoA[$i]) &&               # we didn't already find this job in the queue
                  (index($jobname, $jobnameAR->[$i]) != -1) && # jobname match
 		 ($status ne "Completed")) { # look for a substring if on CLOUD - change this to ne if eq doesn't work
@@ -576,15 +576,15 @@ sub wait_for_cluster_light {
             } #internal if
           } # for loop
       } # cloud segment else
-    } # parse job log loop 
-   
+    } # parse job log loop
+
       # for any job not still in the queue, it should have successfully finished
       for($i = 0; $i < $n; $i++) {
-        $finishedA[$i] = ($ininfoA[$i] == 0) ? 1 : 0; 
+        $finishedA[$i] = ($ininfoA[$i] == 0) ? 1 : 0;
 	}
       sleep(60.); # sleep 1 minute after checking cluster to allow jobs that we think are finished to finish writing output files
     } # end of 'if($do_cluster_check)'
-   
+
     # END OF CLUSTER CHECK BLOCK
     #################################################
 
@@ -593,14 +593,14 @@ sub wait_for_cluster_light {
     # now go through each job and check whether its error and output files exist, for those jobs
     # that our most recent cluster check revealed should be finished (true if $finishedA[$i] is '1')
     # make sure they finished successfully - Skip this if on CLOUD
-    
-    for($i = 0; $i < $n; $i++){ 
+
+    for($i = 0; $i < $n; $i++){
       # sanity check
-      if(($runningA[$i] + $waitingA[$i] + $successA[$i]) != 1) { 
+      if(($runningA[$i] + $waitingA[$i] + $successA[$i]) != 1) {
         die "wait_for_cluster_light() internal error, job $i runningA[$i]: $runningA[$i], waitingA[$i]: $waitingA[$i], successA[$i]: $successA[$i] (exactly 1 of these should be 1 and the others 0)";
-      } 
-    
-      if($successA[$i] == 0) { 
+      }
+
+      if($successA[$i] == 0) {
         # if err file exists
         #    if output file exists
         #       if success string exists: then JOB FINISHED SUCCESSFULLY
@@ -608,31 +608,31 @@ sub wait_for_cluster_light {
         #    else: JOB IS RUNNING FAILED (check by consulting finishedA filled in CLUSTER CHECK BLOCK)
         # else JOB IS WAITING OR FAILED (check by consulting finishedA filled in CLUSTER CHECK BLOCK)
         #
-        if(-e $errnameAR->[$i]) { 
-          # First check for the following rare case: 
+        if(-e $errnameAR->[$i]) {
+          # First check for the following rare case:
           # finishedA[$i] is 1 (qstat/bjobs indicated the job is finished (no longer in queue))
-          # but the expected output file either does not exist or is empty. If this happens, we wait 
-          # up to 20 minutes for it to appear, to guard against the real possibility that the file 
+          # but the expected output file either does not exist or is empty. If this happens, we wait
+          # up to 20 minutes for it to appear, to guard against the real possibility that the file
           # is currently being written to but isn't visible to the file system yet).
-          
+
 	  if($finishedA[$i] && (! -s $outnameAR->[$i])) {
             my $nsleep = 0;
-            while((! -s $outnameAR->[$i]) && ($nsleep < 20)) { 
+            while((! -s $outnameAR->[$i]) && ($nsleep < 20)) {
               sleep(60.);
               $nsleep++;
-            } 
+            }
           }
-          
+
 	  if(-e $outnameAR->[$i]) { # check if output file exists
             if(-s $outnameAR->[$i]) { # check if output file not empty
-              # check for success string in tail output, if it's not there and $finishedA[$i] is 1 (qstat/bjobs indicated this job should be finished) 
-              # then wait a minute and check again (up to 10 times) 
+              # check for success string in tail output, if it's not there and $finishedA[$i] is 1 (qstat/bjobs indicated this job should be finished)
+              # then wait a minute and check again (up to 10 times)
               my $ncheck = 0;
               while(($ncheck == 0) || ($finishedA[$i] == 1 && $ncheck < 20 && $successA[$i] == 0)) { # if finishedA[$i] is 1, we'll stay in this loop until we've found the $success_string or checked for it 10 times
                 my $tail= `tail $outnameAR->[$i]`;
-                foreach $line (split ('\n', $tail)) { 
+                foreach $line (split ('\n', $tail)) {
                   if($line =~ m/\Q$success_string/) {
-                    $successA[$i] = 1; 
+                    $successA[$i] = 1;
                     $nsuccess++;
                     if($runningA[$i] == 1) { $runningA[$i] = 0; $nrunning--; }
                     if($waitingA[$i] == 1) { $waitingA[$i] = 0; $nwaiting--; }
@@ -647,38 +647,38 @@ sub wait_for_cluster_light {
               }
               if($successA[$i] == 0) { # we didn't find the $success_string in the output
                 if($finishedA[$i] == 1) { # if our cluster check revealed this job should be finished, then we waited 20 minutes and it still didn't have success, so die
-                  die "wait_for_cluster_light() job $i finished according to qstat/bjobs, but tail of expected output file $outnameAR->[$i] does not contain: $success_string\n"; 
+                  die "wait_for_cluster_light() job $i finished according to qstat/bjobs, but tail of expected output file $outnameAR->[$i] does not contain: $success_string\n";
                 }
               }
             } #end of 'if(-s $outnameAR->[$i])'
             else { # $outfile exists but is empty, job is running or failed
-              if($finishedA[$i] == 1) { 
+              if($finishedA[$i] == 1) {
                 die "wait_for_cluster_light() job $i finished according to qstat/bjobs, but expected output file $outnameAR->[$i] is empty\n";
               }
-              elsif($runningA[$i] == 0) { 
-                $runningA[$i] = 1; 
+              elsif($runningA[$i] == 0) {
+                $runningA[$i] = 1;
                 $nrunning++;
                 if($waitingA[$i] == 1) { $waitingA[$i] = 0; $nwaiting--; }
               }
             }
           } # end of 'if(-e $outnameAR->[$i])'
           else { # outfile doesn't exist, but errfile does, job is running or failed
-            if($finishedA[$i] == 1) { 
+            if($finishedA[$i] == 1) {
               die "wait_for_cluster_light() job $i finished according to qstat/bjobs, but expected output file $outnameAR->[$i] does not exist\n";
             }
-            elsif($runningA[$i] == 0) { 
-              $runningA[$i] = 1; 
+            elsif($runningA[$i] == 0) {
+              $runningA[$i] = 1;
               $nrunning++;
-              if($waitingA[$i] == 1) { $waitingA[$i] = 0; $nwaiting--; } 
+              if($waitingA[$i] == 1) { $waitingA[$i] = 0; $nwaiting--; }
             }
           }
         } # end of 'if(-e $errnameAR->[$i])'
         else { # err file doesn't exist yet, job is waiting (or failed) or job is running on cloud
           if ($location ne "CLOUD"){
-          if($finishedA[$i] == 1) { 
+          if($finishedA[$i] == 1) {
             die "wait_for_cluster_light() job $i finished according to qstat/bjobs, but expected output ERROR file $errnameAR->[$i] does not exist\n";
           }
-          elsif($waitingA[$i] != 1) { 
+          elsif($waitingA[$i] != 1) {
             die "wait_for_cluster_light() internal error 2, job $i runningA[$i]: $runningA[$i], waitingA[$i]: $waitingA[$i], successA[$i]: $successA[$i] (exactly 1 of these should be 1 and the others 0)";
           }
         }
@@ -686,14 +686,14 @@ sub wait_for_cluster_light {
         else{ # running on Cloud
           if(-e $outnameAR->[$i]) { # check if output file exists
             if(-s $outnameAR->[$i]) { # check if output file not empty
-              # check for success string in tail output, if it's not there and $finishedA[$i] is 1 (qstat/bjobs indicated this job should be finished) 
-              # then wait a minute and check again (up to 10 times) 
+              # check for success string in tail output, if it's not there and $finishedA[$i] is 1 (qstat/bjobs indicated this job should be finished)
+              # then wait a minute and check again (up to 10 times)
               my $ncheck = 0;
               while(($ncheck == 0) || ($finishedA[$i] == 1 && $ncheck < 20 && $successA[$i] == 0)) { # if finishedA[$i] is 1, we'll stay in this loop until we've found the $success_string or checked for it 10 times
                 my $tail= `tail $outnameAR->[$i]`;
-		foreach $line (split ('\n', $tail)) { 
+		foreach $line (split ('\n', $tail)) {
 		if($line =~ m/\Q$success_string/) {
-                    $successA[$i] = 1; 
+                    $successA[$i] = 1;
                     $nsuccess++;
                     if($runningA[$i] == 1) { $runningA[$i] = 0; $nrunning--; }
                     if($waitingA[$i] == 1) { $waitingA[$i] = 0; $nwaiting--; }
@@ -708,7 +708,7 @@ sub wait_for_cluster_light {
               }
               if($successA[$i] == 0) { # we didn't find the $success_string in the output
                 if($finishedA[$i] == 1) { # if our cluster check revealed this job should be finished, then we waited 20 minutes and it still didn't have success, so die
-                  die "wait_for_cluster_light() job $i finished according to qstat/bjobs, but tail of expected output file $outnameAR->[$i] does not contain: $success_string\n"; 
+                  die "wait_for_cluster_light() job $i finished according to qstat/bjobs, but tail of expected output file $outnameAR->[$i] does not contain: $success_string\n";
                 }
               }
             } #end of 'if(-s $outnameAR->[$i])'
@@ -716,21 +716,21 @@ sub wait_for_cluster_light {
               if($finishedA[$i] == 1) {
 		      #die "wait_for_cluster_light() job $i finished according to qstat/bjobs, but expected output file $outnameAR->[$i] is empty\n";
               }
-              elsif($runningA[$i] == 0) { 
-                $runningA[$i] = 1; 
+              elsif($runningA[$i] == 0) {
+                $runningA[$i] = 1;
                 $nrunning++;
                 if($waitingA[$i] == 1) { $waitingA[$i] = 0; $nwaiting--; }
               }
             }
           } # end of 'if(-e $outnameAR->[$i])'
           else { # outfile doesn't exist, but errfile does, job is running or failed
-            if($finishedA[$i] == 1) { 
+            if($finishedA[$i] == 1) {
 		    #die "wait_for_cluster_light() job $i finished according to qstat/bjobs, but expected output file $outnameAR->[$i] does not exist\n";
             }
-            elsif($runningA[$i] == 0) { 
-              $runningA[$i] = 1; 
+            elsif($runningA[$i] == 0) {
+              $runningA[$i] = 1;
               $nrunning++;
-              if($waitingA[$i] == 1) { $waitingA[$i] = 0; $nwaiting--; } 
+              if($waitingA[$i] == 1) { $waitingA[$i] = 0; $nwaiting--; }
             }
           }
         }
@@ -738,26 +738,26 @@ sub wait_for_cluster_light {
 	   }
   } # end of 'for($i = 0; $i < $n; $i++)'
 
-    if($nwaiting > 0) { $max_wait_secs = time() - $start_time; } 
+    if($nwaiting > 0) { $max_wait_secs = time() - $start_time; }
     $minutes_elapsed = (time() - $start_time) / 60;
-    if($program ne "") { 
-      if($nsuccess == $n || $ncycle_tot % $print_freq == 0) { 
+    if($program ne "") {
+      if($nsuccess == $n || $ncycle_tot % $print_freq == 0) {
         my $outstr = sprintf("  %-15s  %-10s  %10s  %10s  %10s  %10s%s\n", $program, "cluster", $nsuccess, $nrunning, $nwaiting, Bio::Rfam::Utils::format_time_string(time() - $start_time), $extra_note);
-        $extra_note = ""; # only print this once 
+        $extra_note = ""; # only print this once
         if($do_stdout) { print STDOUT $outstr; }
         if($outFH ne "") { print $outFH $outstr; }
       }
     }
     if(defined $max_minutes && $max_minutes != -1 && $minutes_elapsed > $max_minutes) { die "wait_for_cluster_light(), reached maximum time limit of $max_minutes minutes, exiting."; }
     # now wait for a while before reexamining
-    if($nsuccess != $n) { 
-      sleep($sleep_nsecs); 
+    if($nsuccess != $n) {
+      sleep($sleep_nsecs);
       $ncycle++;
       $ncycle_tot++;
     }
   }
   return $max_wait_secs;
-  # The only way we'll get here is if all jobs are finished 
+  # The only way we'll get here is if all jobs are finished
   # and have $success_string in output file, if not, we'll have die'd earlier
 }
 
@@ -768,14 +768,14 @@ sub wait_for_cluster_light {
   Title    : format_time_string()
   Incept   : EPN, Tue Apr  2 11:10:38 2013
   Usage    : format_time_string($seconds)
-  Function : Return string in "hh:mm:ss" format given 
-           : a number of seconds ($seconds). 
+  Function : Return string in "hh:mm:ss" format given
+           : a number of seconds ($seconds).
   Args     : $seconds: number of seconds
   Returns  : void
 
 =cut
 
-sub format_time_string { 
+sub format_time_string {
   my ($seconds) = @_;
 
   my $h = int($seconds / 3600.);
@@ -794,19 +794,19 @@ sub format_time_string {
   Incept   : IK, Wed Mar 6 20:08:10 2019
   Usage    : delete_completed_k8s_jobs($user, $tier)
   Function : Delete all k8s jobs of a specific
-           : user. 
+           : user.
   Args     : $user: user id
            : $tier: backend/frontend
   Returns  : void
 
 =cut
 
-sub delete_completed_k8s_jobs { 
+sub delete_completed_k8s_jobs {
   my ($user, $tier) = @_;
 
   my $cmd = "kubectl delete jobs --selector=user=$user --selector=tier=$tier";
   run_local_command($cmd);
-  
+
 }
 
 #-------------------------------------------------------------------------------
@@ -816,7 +816,7 @@ sub delete_completed_k8s_jobs {
   Title    : concatenate_files()
   Incept   : EPN, Tue Apr  2 18:58:54 2013
   Usage    : concatenate_files($fileAR, $dest_file, $unlink_flag)
-  Function : Concatenate all files in @{$fileAR} to create a new 
+  Function : Concatenate all files in @{$fileAR} to create a new
            : file $dest_file. If $unlink_file is '1' then unlink
            : all files in $fileAR before returning.
   Args     : $fileAR: ref to array of files to concatenate
@@ -833,7 +833,7 @@ sub concatenate_files {
   my $n = scalar(@{$fileAR});
   my $i;
   open(OUT, ">" . $dest_file) || die "ERROR unable to open $dest_file for writing";
-  for ($i = 0; $i < $n; $i++) { 
+  for ($i = 0; $i < $n; $i++) {
     open(IN, $fileAR->[$i]) || die "ERROR unable to open $fileAR->[$i] for reading";
     while(<IN>) { print OUT $_; }
     close(IN);
@@ -841,8 +841,8 @@ sub concatenate_files {
   close(OUT);
 
   # unlink files if nec, do this after we concatenate, in case something goes wrong
-  if($unlink_flag) { 
-    for ($i = 0; $i < $n; $i++) { 
+  if($unlink_flag) {
+    for ($i = 0; $i < $n; $i++) {
       unlink $fileAR->[$i];
     }
   }
@@ -857,8 +857,8 @@ sub concatenate_files {
   Incept   : pg5
   Usage    : tax2kingdom($species)
   Function : Return kingdom string given a taxonomy string.
-  Args     : $species: the taxonomic string 
-  Returns  : kingdom string 
+  Args     : $species: the taxonomic string
+  Returns  : kingdom string
 
 =cut
 
@@ -869,10 +869,10 @@ sub tax2kingdom {
     if ($species=~/^(.+?);\s+(.+?)\.*?;/){
 	$kingdom = "$1; $2";
     }
-    if(! defined $kingdom) { 
-      die "FATAL: failed to parse a kingdom from species string: [$species]. !"; 
+    if(! defined $kingdom) {
+      die "FATAL: failed to parse a kingdom from species string: [$species]. !";
     }
-    
+
     return $kingdom;
 }
 
@@ -885,28 +885,28 @@ sub tax2kingdom {
   Usage    : capitalize_token_in_taxstring($taxstr, $level)
   Function : Given a taxonomy string capitalize a given token within it.
            : Tokens are delimited by ';'.
-  Args     : $taxstr: the taxonomic string 
+  Args     : $taxstr: the taxonomic string
            : $level:  the level of token to capitalize NOTE '0' means 1st token [0..ntok-1]
   Returns  : $taxstr with token number $level capitalize
   Dies     : If there are less than ($level+1) tokens in $taxstr.
 
 =cut
 
-sub capitalize_token_in_taxstring { 
+sub capitalize_token_in_taxstring {
   my ($taxstr, $level) = @_;
   if(! defined $level) { die "ERROR, level not defined in capitalize_token_in_taxstring"; }
-  
+
   my @elA = split(";", $taxstr);
   my $ntok = scalar(@elA);
   if($ntok < ($level+1)) { $level++; die "ERROR, trying to capitalize token number $level but only $ntok exist in $taxstr"; }
-  
+
   my $ret_tok = "";
-  for(my $i = 0; $i < $ntok; $i++) { 
+  for(my $i = 0; $i < $ntok; $i++) {
     if($level == $i) { $elA[$i] =~ tr/a-z/A-Z/; }
     $ret_tok .= $elA[$i];
     if($i < ($ntok-1)) { $ret_tok .= ";"; }
   }
-  
+
   return $ret_tok;
 }
 
@@ -919,24 +919,24 @@ sub capitalize_token_in_taxstring {
   Incept   : EPN, Mon Apr 28 11:38:15 2014
   Usage    : pad_tokens_in_tax_string($taxstr, $widthAR, $sepchar)
   Function : Given a taxonomy string and a width for each token, return a string
-           : where each string is printed as a separate string of the proper 
+           : where each string is printed as a separate string of the proper
            : width, for pretty output formatting.
-  Args     : $taxstr:   the taxonomic string 
+  Args     : $taxstr:   the taxonomic string
            : $widthAR:  ref to array of width for each token
            : $sepchar:  character to separate tokens (e.g. ';' '|' or ' ')
   Returns  : $taxstr with new desired spacing
   Dies     : if more tokens in $taxstr than widths in @{$widthAR}
 =cut
 
-sub pad_tokens_in_taxstring { 
+sub pad_tokens_in_taxstring {
   my ($taxstr, $widthAR, $sepchar) = @_;
-  
+
   my @elA = split(";", $taxstr);
   my $ntok = scalar(@elA);
   my $nwid = scalar(@{$widthAR});
   if($ntok > $nwid) { die "ERROR in pad_tokens_in_taxstring: $ntok tokens in taxstr, but only $nwid widths"; }
   my $retstr = "";
-  for(my $i = 0; $i < $ntok; $i++) { 
+  for(my $i = 0; $i < $ntok; $i++) {
     $retstr .= sprintf("%-*s%s", $widthAR->[$i], $elA[$i], $sepchar);
   }
   return $retstr;
@@ -970,7 +970,7 @@ sub nse_breakdown {
 
     if($sqname =~ m/^(\S+)\/(\d+)\-(\d+)\s*/) {
       ($n, $s, $e) = ($1,$2,$3);
-      $str = ($s <= $e) ? 1 : -1; 
+      $str = ($s <= $e) ? 1 : -1;
       return (1, $n, $s, $e, $str);
     }
     return (0, "", 0, 0, 0);
@@ -1001,7 +1001,7 @@ sub nse_sqlen {
       if($start <= $end) { $sqlen = $end - $start + 1; }
       else               { $sqlen = $start - $end + 1; }
     }
-    else { 
+    else {
       croak "invalid name $nse does not match name/start-end format\n";
     }
     return $sqlen;
@@ -1079,9 +1079,9 @@ sub overlap_nres_two_nse {
   Incept   : EPN, Thu Jan 31 08:50:55 2013
   Usage    : overlap_fraction($from1, $to1, $from2, $to2)
   Function : Returns fractional overlap of two regions.
-           : If $from1 is <= $to1 we assume first  region is 
+           : If $from1 is <= $to1 we assume first  region is
            : on + strand, else it's on - strand.
-           : If $from2 is <= $to2 we assume second region is 
+           : If $from2 is <= $to2 we assume second region is
            : on + strand, else it's on - strand.
            : If regions are on opposite strand, return 0.
   Args     : $from1: start point of first region (maybe < or > than $to1)
@@ -1094,7 +1094,7 @@ sub overlap_nres_two_nse {
 
 sub overlap_fraction {
     my($from1, $to1, $from2, $to2) = @_;
-    
+
     my($a1, $b1, $strand1, $a2, $b2, $strand2);
 
     if($from1 <= $to1) { $a1 = $from1; $b1 = $to1;   $strand1 = 1;  }
@@ -1102,9 +1102,9 @@ sub overlap_fraction {
 
     if($from2 <= $to2) { $a2 = $from2; $b2 = $to2;   $strand2 = 1;  }
     else               { $a2 = $to2;   $b2 = $from2; $strand2 = -1; }
-    
-    if($strand1 != $strand2) { 
-	return 0.; 
+
+    if($strand1 != $strand2) {
+	return 0.;
     }
 
     my $L1 = $b1 - $a1 + 1;
@@ -1123,9 +1123,9 @@ sub overlap_fraction {
   Incept   : EPN, Thu Aug  8 18:41:16 2013
   Usage    : overlap_nres($from1, $to1, $from2, $to2)
   Function : Returns number of residues of overlap between two regions.
-           : If $from1 is <= $to1 we assume first region is 
+           : If $from1 is <= $to1 we assume first region is
            : on + strand, else it's on - strand.
-           : If $from2 is <= $to2 we assume second region is 
+           : If $from2 is <= $to2 we assume second region is
            : on + strand, else it's on - strand.
            : If regions are on opposite strand, return 0.
   Args     : $from1: start point of first region (maybe < or > than $to1)
@@ -1138,7 +1138,7 @@ sub overlap_fraction {
 
 sub overlap_nres_or_full {
     my($from1, $to1, $from2, $to2) = @_;
-    
+
     my($a1, $b1, $strand1, $a2, $b2, $strand2);
 
     if($from1 <= $to1) { $a1 = $from1; $b1 = $to1;   $strand1 = 1;  }
@@ -1146,9 +1146,9 @@ sub overlap_nres_or_full {
 
     if($from2 <= $to2) { $a2 = $from2; $b2 = $to2;   $strand2 = 1;  }
     else               { $a2 = $to2;   $b2 = $from2; $strand2 = -1; }
-    
-    if($strand1 != $strand2) { 
-	return 0.; 
+
+    if($strand1 != $strand2) {
+	return 0.;
     }
 
     my $L1 = $b1 - $a1 + 1;
@@ -1178,14 +1178,14 @@ sub overlap_nres_or_full {
 
 sub overlap_nres_strict {
     my ($from1, $to1, $from2, $to2) = @_;
-    
+
     if($from1 > $to1) { croak "overlap_nres_strict(), from1 > to1\n"; }
     if($from2 > $to2) { croak "overlap_nres_strict(), from2 > to2\n"; }
 
     # Given: $from1 <= $to1 and $from2 <= $to2.
 
     # Swap if nec so that $from1 <= $from2.
-    if($from1 > $from2) { 
+    if($from1 > $from2) {
 	my $tmp;
 	$tmp   = $from1; $from1 = $from2; $from2 = $tmp;
 	$tmp   =   $to1;   $to1 =   $to2;   $to2 = $tmp;
@@ -1193,7 +1193,7 @@ sub overlap_nres_strict {
 
     # 3 possible cases:
     # Case 1. $from1 <=   $to1 <  $from2 <=   $to2  Overlap is 0
-    # Case 2. $from1 <= $from2 <=   $to1 <    $to2  
+    # Case 2. $from1 <= $from2 <=   $to1 <    $to2
     # Case 3. $from1 <= $from2 <=   $to2 <=   $to1
     if($to1 < $from2) { return 0; }                    # case 1
     if($to1 <   $to2) { return ($to1 - $from2 + 1); }  # case 2
@@ -1208,13 +1208,13 @@ sub overlap_nres_strict {
   Title    : overlap_nres_either_strand
   Incept   : EPN, Thu Oct 10 09:24:57 2013
   Usage    : overlap_nres_either_strand($from1, $to1, $from2, $to2)
-  Function : Returns number of overlapping residues between two 
+  Function : Returns number of overlapping residues between two
            : regions, irrespective of strand. That is, if two
            : regions overlap by 10 residues but on opposite residues
            : we return 10. (overlap_nres_strict() would return 0.)
-           : If $from1 is <= $to1 we assume first region is 
+           : If $from1 is <= $to1 we assume first region is
            : on + strand, else it's on - strand.
-           : If $from2 is <= $to2 we assume second region is 
+           : If $from2 is <= $to2 we assume second region is
            : on + strand, else it's on - strand.
   Args     : $from1: start point of first region (must be <= $to1)
            : $to1:   end   point of first region
@@ -1235,7 +1235,7 @@ sub overlap_nres_either_strand {
     else                 { $strand2 = -1; $tmpfrom2 = $to2;   $tmpto2 = $from2; }
 
     my $nres_overlap = overlap_nres_strict($tmpfrom1, $tmpto1, $tmpfrom2, $tmpto2);
-    
+
     return($nres_overlap, $strand1, $strand2);
 }
 
@@ -1256,7 +1256,7 @@ sub overlap_nres_either_strand {
 
 =cut
 
-sub log_output_rfam_banner { 
+sub log_output_rfam_banner {
   my ($fh, $executable, $banner, $also_stdout, $dlen) = @_;
 
   if(! defined $dlen) { $dlen = 80; }
@@ -1283,7 +1283,7 @@ sub log_output_rfam_banner {
            : $cwidth:      column width, usually 40
            : $user:        user name
            : $config:      Bio::Rfam::Config object
-           : $desc:        famObj->desc file 
+           : $desc:        famObj->desc file
            : $also_stdout: '1' to also output to stdout, '0' not to
   Returns  : void
 =cut
@@ -1299,10 +1299,10 @@ sub log_output_preamble {
   Bio::Rfam::Utils::printToFileAndOrStdout($fh, sprintf ("%-*s%s\n", $cwidth, "# process-id:", $$),              $also_stdout);
   Bio::Rfam::Utils::printToFileAndOrStdout($fh, sprintf ("%-*s%s\n", $cwidth, "# location:", $config->location), $also_stdout);
   Bio::Rfam::Utils::printToFileAndOrStdout($fh, sprintf ("%-*s%s\n", $cwidth, "# family-id:", $desc->ID),        $also_stdout);
-  if(defined $desc->AC) { 
+  if(defined $desc->AC) {
     Bio::Rfam::Utils::printToFileAndOrStdout($fh, sprintf ("%-*s%s\n", $cwidth, "# family-acc:", $desc->AC),       $also_stdout);
   }
-  else { 
+  else {
     Bio::Rfam::Utils::printToFileAndOrStdout($fh, sprintf ("%-*s%s\n", $cwidth, "# family-acc:", "undef"),       $also_stdout);
   }
   return;
@@ -1322,7 +1322,7 @@ sub log_output_preamble {
   Returns  : void
 =cut
 
-sub log_output_tail { 
+sub log_output_tail {
   my ($fh, $start_time, $also_stdout) = @_;
 
   Bio::Rfam::Utils::printToFileAndOrStdout($fh, sprintf("#\n"), $also_stdout);
@@ -1342,19 +1342,19 @@ sub log_output_tail {
   Function : Outputs a divider line to $fh and optionally stdout.
   Args     : $fh:          file handle to output to
            : $also_stdout: '1' to also output to stdout, '0' not to
-           : $len:         length of divider line, 80 if ! defined, 
+           : $len:         length of divider line, 80 if ! defined,
   Returns  : void
 
 =cut
 
-sub log_output_divider { 
+sub log_output_divider {
   my ($fh, $also_stdout, $len) = @_;
   if(! defined $len || $len eq "") { $len = 80; }
   my $str = "# -";
   my $curlen = 3;
   while($curlen < $len) { $str .= " -"; $curlen += 2; }
   $str .= "\n";
-  
+
   print $fh $str; if($also_stdout) { print $str; }
 
   return;
@@ -1377,7 +1377,7 @@ sub log_output_divider {
 
 =cut
 
-sub log_output_header { 
+sub log_output_header {
   my ($fh, $user, $date, $dbchoice, $also_stdout) = @_;
 
   my $str;
@@ -1410,7 +1410,7 @@ sub log_output_header {
 
 =cut
 
-sub log_output_progress_column_headings { 
+sub log_output_progress_column_headings {
   my ($fh, $header_str, $also_stdout) = @_;
 
   my $str;
@@ -1441,14 +1441,14 @@ sub log_output_progress_column_headings {
 
 =cut
 
-sub log_output_progress_skipped { 
+sub log_output_progress_skipped {
   my ($fh, $stage, $also_stdout) = @_;
 
   my $str = sprintf ("  %-15s  %-10s  %10s  %10s  %10s  %10s\n", $stage, "skipped", "-", "-", "-", "-");
   print $fh $str; if($also_stdout) { print $str; }
-  
+
   return;
-}  
+}
 
 #-------------------------------------------------------------------------------
 
@@ -1463,21 +1463,21 @@ sub log_output_progress_skipped {
            : $run_secs:    number of seconds script has been running
            : $nrunning:    number of jobs running (or about to be)
            : $nfinished:   number of jobs finished
-           : $extra_note:  note to add at end of line ("" for none) 
+           : $extra_note:  note to add at end of line ("" for none)
            : $also_stdout: '1' to also output to stdout, '0' not to
   Returns  : void
 
 =cut
 
-sub log_output_progress_local { 
+sub log_output_progress_local {
   my ($fh, $stage, $run_secs, $nrunning, $nfinished, $extra_note, $also_stdout) = @_;
 
   if($extra_note ne "") { $extra_note = "  " . $extra_note; }
   my $str = sprintf ("  %-15s  %-10s  %10s  %10s  %10s  %10s%s\n", $stage, "local", $nfinished, $nrunning, "0", Bio::Rfam::Utils::format_time_string($run_secs), $extra_note);
   print $fh $str; if($also_stdout) { print $str; }
-  
+
   return;
-}  
+}
 
 #-------------------------------------------------------------------------------
 
@@ -1495,7 +1495,7 @@ sub log_output_progress_local {
 
 =cut
 
-sub log_output_file_summary_column_headings { 
+sub log_output_file_summary_column_headings {
   my ($fh, $also_stdout, $fwidth, $dwidth) = @_;
 
   if(! defined $fwidth) { $fwidth = 20; }
@@ -1534,7 +1534,7 @@ sub log_output_file_summary_column_headings {
 
 =cut
 
-sub log_output_file_summary { 
+sub log_output_file_summary {
   my ($fh, $filename, $desc, $also_stdout, $fwidth, $dwidth) = @_;
 
   if(! defined $fwidth) { $fwidth = 20; }
@@ -1560,7 +1560,7 @@ sub log_output_file_summary {
 
 =cut
 
-sub log_output_timing_summary_column_headings { 
+sub log_output_timing_summary_column_headings {
   my ($fh, $also_stdout) = @_;
 
   my $str;
@@ -1585,7 +1585,7 @@ sub log_output_timing_summary_column_headings {
   Usage    : Bio::Rfam::Utils::log_output_timing_summary($fh, $also_stdout);
   Function : Outputs timing summary
   Args     : $fh:           file handle to output to
-           : $stage:        stage 
+           : $stage:        stage
            : $wall_secs:    number of seconds elapsed
            : $tot_cpu_secs: total number of CPU seconds reported
            : $wait_secs:    total number of seconds waiting in queue
@@ -1596,23 +1596,23 @@ sub log_output_timing_summary_column_headings {
 
 =cut
 
-sub log_output_timing_summary { 
+sub log_output_timing_summary {
   my ($fh, $stage, $wall_secs, $tot_cpu_secs, $wait_secs, $max_elp_secs, $ideal_secs, $also_stdout) = @_;
 
   # $ideal_secs: time it would have taken if all jobs took equal time (the goal of parallelization)
   # efficiency: $ideal_secs / $max_elp_secs
   my $efficiency = 1.0;
-  if($ideal_secs > 0 && ($ideal_secs < $max_elp_secs)) { 
+  if($ideal_secs > 0 && ($ideal_secs < $max_elp_secs)) {
     $efficiency = $ideal_secs / $max_elp_secs;
   }
   # wait fraction: fraction of time spent waiting
   my $wait_fract = 0.;
-  if($wait_secs ne "-" && $wait_secs > 0) { 
+  if($wait_secs ne "-" && $wait_secs > 0) {
     if($wait_secs > $wall_secs) { die "ERROR in log_output_timing_summary(): wait_secs exceeds wall_secs ($wait_secs > $wall_secs)"; }
     $wait_fract = $wait_secs / $wall_secs;
   }
   my $str = sprintf ("  %-15s  %10s  %10s  %10s  %10s  %10.2f  %10.2f\n",
-                     $stage, 
+                     $stage,
                      Bio::Rfam::Utils::format_time_string($wall_secs),
                      Bio::Rfam::Utils::format_time_string($ideal_secs),
                      Bio::Rfam::Utils::format_time_string($tot_cpu_secs),
@@ -1633,10 +1633,10 @@ sub log_output_timing_summary {
     Incept   : EPN, Thu Nov 14 10:02:34 2013
     Usage    : fetchSubseqsGivenNseArray($nseAR, $fetchfile, $textw, $outfile, $logFH, $do_stdout)
     Function : Fetch all hits listed in name/start-end format in @{$nseAR}
-             : from $fetchfile and output to $outfile (or return 
+             : from $fetchfile and output to $outfile (or return
              : seqstring if $outfile is "" or undefined).
-    Args     : $nseAR:     ref to array of name/start-end, we will fetch a subset 
-             :             from seq 'name' from 'start' to 'end' and rename the 
+    Args     : $nseAR:     ref to array of name/start-end, we will fetch a subset
+             :             from seq 'name' from 'start' to 'end' and rename the
              :             subseq 'name/start-end'.
              : $fetchfile: file to fetch seqs from
              : $textw:     width of FASTA seq lines, usually $FASTATEXTW, -1 for unlimited
@@ -1648,7 +1648,7 @@ sub log_output_timing_summary {
              : $seqstring: string of all seqs, IFF $outfile is undefined or ""
 =cut
 
-sub fetchSubseqsGivenNseArray { 
+sub fetchSubseqsGivenNseArray {
   my ($nseAR, $fetchfile, $textw, $outfile, $logFH, $do_stdout) = @_;
 
   if(! defined $textw) { $textw = $FASTATEXTW; }
@@ -1656,20 +1656,20 @@ sub fetchSubseqsGivenNseArray {
   my @fetchAA; # array with info on seqs to fetch
   my $nseq = 0;
   my $nres = 0;
-  foreach my $nse (@{$nseAR}) { 
+  foreach my $nse (@{$nseAR}) {
     my ($validated, $name, $start, $end) = Bio::Rfam::Utils::nse_breakdown($nse);
     if(! $validated) { die "ERROR, $nse not in name/start-end format"; }
     $nres += Bio::Rfam::Utils::nse_sqlen($nse);
     $nseq++;
-    push(@fetchAA, [$nse, $start, $end, $name]); 
+    push(@fetchAA, [$nse, $start, $end, $name]);
   }
   close(IN);
 
   my $seqstring = undef;
-  if(defined $outfile && $outfile ne "") { 
-    Bio::Rfam::Utils::fetch_from_sqfile_wrapper($fetchfile, \@fetchAA, 1, $textw, $logFH, 1, $outfile); 
+  if(defined $outfile && $outfile ne "") {
+    Bio::Rfam::Utils::fetch_from_sqfile_wrapper($fetchfile, \@fetchAA, 1, $textw, $logFH, 1, $outfile);
   }
-  else { 
+  else {
     $seqstring = Bio::Rfam::Utils::fetch_from_sqfile_wrapper($fetchfile, \@fetchAA, 1, $textw, $logFH, 1, ""); # "" means return a string of all seqs
   }
 
@@ -1684,7 +1684,7 @@ sub fetchSubseqsGivenNseArray {
   Incept   : EPN, Thu Oct 31 15:07:56 2013
   Usage    : Bio::Rfam::Utils::fetch_seqs_wrapper($fetchfile, $fetchAAR, $logFH, $also_stdout, $seqfile);
   Function : Fetches complete sequences or subsequences (if $do_subseqs == 1) from a
-           : sequence file and either outputs them to a file or returns them 
+           : sequence file and either outputs them to a file or returns them
            : concatenated together in a string.
   Args     : $fetchfile:    file to fetch seqs from
            : $fetchAR:      reference to array of names to fetch, or 2D arrays (if $do_subseqs),
@@ -1698,7 +1698,7 @@ sub fetchSubseqsGivenNseArray {
 
 =cut
 
-sub fetch_from_sqfile_wrapper { 
+sub fetch_from_sqfile_wrapper {
   my ($fetchfile, $fetchAR, $do_subseqs, $textw, $logFH, $do_stdout, $outfile) = @_;
 
   if(! defined $textw) { $textw = $FASTATEXTW; }
@@ -1709,21 +1709,21 @@ sub fetch_from_sqfile_wrapper {
 
   my $ret_str = "";
 
-  my $fetch_start_time = time();  
-  
-  if(defined $logFH) { 
+  my $fetch_start_time = time();
+
+  if(defined $logFH) {
     Bio::Rfam::Utils::log_output_progress_local($logFH, "seqfetch", time() - $fetch_start_time, 1, 0, sprintf("[fetching %d seqs]", scalar(@{$fetchAR})), $do_stdout);
   }
-  if(defined $outfile && $outfile ne "") { 
+  if(defined $outfile && $outfile ne "") {
     if($do_subseqs) { $fetch_sqfile->fetch_subseqs($fetchAR, $textw, $outfile); }
     else            { $fetch_sqfile->fetch_seqs_given_names($fetchAR, $textw, $outfile); }
-  } 
-  else { # outfile is undefined, 
+  }
+  else { # outfile is undefined,
     if($do_subseqs) { $ret_str = $fetch_sqfile->fetch_subseqs($fetchAR, $textw); }
     else            { $ret_str = $fetch_sqfile->fetch_seqs_given_names($fetchAR, $textw); }
-  } 
+  }
 
-  if(defined $logFH) { 
+  if(defined $logFH) {
     Bio::Rfam::Utils::log_output_progress_local($logFH, "seqfetch", time() - $fetch_start_time, 0, 1, "", $do_stdout);
   }
 
@@ -1745,7 +1745,7 @@ sub fetch_from_sqfile_wrapper {
 
 =cut
 
-sub remove_descriptions_from_fasta_seq_string { 
+sub remove_descriptions_from_fasta_seq_string {
   my ($seqstring) = @_;
 
   # want to only remove Descriptions
@@ -1765,7 +1765,7 @@ sub remove_descriptions_from_fasta_seq_string {
   Function : Extract filename, removing path prefix.
            : Based on easel''s esl_FileTail().
            :     '/foo/bar/baz.1' becomes 'baz.1';
-           :     'foo/bar'        becomes 'bar'; 
+           :     'foo/bar'        becomes 'bar';
            :     'foo'            becomes 'foo'; and
            :     '/'              becomes the empty string.
   Args     : $filePath: full path to file
@@ -1773,9 +1773,9 @@ sub remove_descriptions_from_fasta_seq_string {
 
 =cut
 
-sub file_tail { 
+sub file_tail {
   my ($filePath) = @_;
-  
+
   $filePath =~ s/^.+\///;
   return $filePath;
 }
@@ -1795,12 +1795,12 @@ sub file_tail {
 
 =cut
 
-sub fileToString { 
+sub fileToString {
   my ($filePath) = @_;
-  
+
   my $ret_str = "";
   open(IN, $filePath) || die "ERROR unable to open $filePath, to convert it to a string";
-  while(my $line = <IN>) { 
+  while(my $line = <IN>) {
     $ret_str .= $line;
   }
   return $ret_str;
@@ -1822,11 +1822,11 @@ sub fileToString {
 
 =cut
 
-sub fileToArray { 
+sub fileToArray {
   my ($filePath, $AR, $remove_newlines) = @_;
-  
+
   open(IN, $filePath) || die "ERROR unable to open $filePath, to convert it to a string";
-  while(my $line = <IN>) { 
+  while(my $line = <IN>) {
     if(defined $remove_newlines && $remove_newlines) { chomp $line; }
     push(@{$AR}, $line);
   }
@@ -1849,19 +1849,19 @@ sub fileToArray {
 
 =cut
 
-sub checkIfTwoFilesAreIdentical { 
+sub checkIfTwoFilesAreIdentical {
   my ($file1, $file2) = @_;
 
   my ($line1, $line2);
   open(IN1, $file1) || die "ERROR unable to open $file1 in checkIfTwoFilesAreIdentical()";
   open(IN2, $file2) || die "ERROR unable to open $file2 in checkIfTwoFilesAreIdentical()";
 
-  while($line1 = <IN1>) { 
+  while($line1 = <IN1>) {
     if(! ($line2 = <IN2>)) { close(IN1); close(IN2); return 0; } # more lines in file 1 than file 2
     if($line1 ne $line2)   { close(IN1); close(IN2); return 0; } # difference in current line
   }
   while($line2 = <IN2>) { close(IN1); close(IN2); return 0; } # more lines in file 2 than file 1
-  
+
   close(IN1);
   close(IN2);
 
@@ -1878,7 +1878,7 @@ sub checkIfTwoFilesAreIdentical {
   Function : Print string to a file handle and/or to stdout.
   Args     : $fh:        file handle to print to, "" to not print to fh
            : $str:       string to print
-           : $do_stdout: 1 to print to stdout, 2 to print to stderr, 0 to 
+           : $do_stdout: 1 to print to stdout, 2 to print to stderr, 0 to
            :             print to neither
   Returns  : void
 
@@ -1887,13 +1887,13 @@ sub checkIfTwoFilesAreIdentical {
 sub printToFileAndOrStdout {
   my ($fh, $str, $do_stdout) = @_;
 
-  if($fh ne "") { 
+  if($fh ne "") {
     print $fh $str;
-  } 
-  if(defined $do_stdout && $do_stdout == 2) { 
+  }
+  if(defined $do_stdout && $do_stdout == 2) {
     print STDERR $str;
   }
-  elsif((! defined $do_stdout) || $do_stdout) { 
+  elsif((! defined $do_stdout) || $do_stdout) {
     print $str;
   }
 
@@ -1944,9 +1944,9 @@ sub youngerThan {
   if ($age2 < $age1) {
 	return 1;
  }
-  
-  #if( -M $file1 <= -M $file2 ) { 
-  #  return 1; 
+
+  #if( -M $file1 <= -M $file2 ) {
+  #  return 1;
   #}
   return 0;
 }
@@ -1958,23 +1958,23 @@ sub youngerThan {
   Title    : checkStderrFile
   Incept   : EPN, Tue Apr 30 01:20:50 2013
   Usage    : checkStderrFile($config->location, $calibrate_errO)
-  Function : Check output printed to STDERR in location-dependent. 
+  Function : Check output printed to STDERR in location-dependent.
            : If anything looks like a real error, then die.
   Args     : $location, $errFile
   Returns  : void
 
 =cut
 
-sub checkStderrFile { 
+sub checkStderrFile {
   my ($location, $errFile) = @_;
 
-  if(-s $errFile) { 
-    if($location eq "JFRC") { 
+  if(-s $errFile) {
+    if($location eq "JFRC") {
       die "Error output, see $errFile";
     }
-    elsif($location eq "EBI") { 
+    elsif($location eq "EBI") {
       open(IN, $errFile) || die "ERROR unable to open $errFile";
-      while(my $line = <IN>) { 
+      while(my $line = <IN>) {
         if($line !~ m/^Warning/) {
           die "Error output, see $errFile";
         }
@@ -2003,7 +2003,7 @@ sub sumArray {
 
   my $i;
   my $sum = 0;
-  for($i = 0; $i < $n; $i++) { 
+  for($i = 0; $i < $n; $i++) {
     $sum += $AR->[$i];
   }
   return $sum;
@@ -2019,7 +2019,7 @@ sub sumArray {
   Function : Set all values in an array to $val.
   Args     : $AR:  ref to array to sum
            : $val: to set all array elements to
-           : $n:   size of array 
+           : $n:   size of array
   Returns  : void
 
 =cut
@@ -2053,7 +2053,7 @@ sub maxArray {
   if($n == 0) { die "ERROR, maxArray entered with empty array";  }
 
   my $max = $AR->[0];
-  for($i = 0; $i < $n; $i++) { 
+  for($i = 0; $i < $n; $i++) {
     $max = ($AR->[$i] > $max) ? $AR->[$i] : $max;
   }
   return $max;
@@ -2080,7 +2080,7 @@ sub minArray {
   if($n == 0) { die "ERROR, minArray entered with empty array"; }
 
   my $min = $AR->[0];
-  for($i = 0; $i < $n; $i++) { 
+  for($i = 0; $i < $n; $i++) {
     $min = ($AR->[$i] < $min) ? $AR->[$i] : $min;
   }
   return $min;
@@ -2101,14 +2101,14 @@ sub minArray {
 
 =cut
 
-sub maxLenStringInArray { 
+sub maxLenStringInArray {
   my ($AR, $n) = @_;
 
   if(! defined $n) { $n = scalar(@{$AR}); }
   if($n == 0) { return 0; }
   my $i;
   my $xlen = length($AR->[0]);
-  for($i = 1; $i < $n; $i++) { 
+  for($i = 1; $i < $n; $i++) {
     my $len = length($AR->[$i]);
     if($len > $xlen) { $xlen = $len; }
   }
@@ -2130,14 +2130,14 @@ sub maxLenStringInArray {
 
 =cut
 
-sub minLenStringInArray { 
+sub minLenStringInArray {
   my ($AR, $n) = @_;
 
   if(! defined $n) { $n = scalar(@{$AR}); }
   if($n == 0) { return 0; }
   my $i;
   my $nlen = length($AR->[0]);
-  for($i = 1; $i < $n; $i++) { 
+  for($i = 1; $i < $n; $i++) {
     my $len = length($AR->[$i]);
     if($len < $nlen) { $nlen = $len; }
   }
@@ -2158,11 +2158,11 @@ sub minLenStringInArray {
 
 =cut
 
-sub monocharacterString { 
+sub monocharacterString {
   my ($char, $len) = @_;
 
   my $ret_str = "";
-  for(my $i = 0; $i < $len; $i++) { 
+  for(my $i = 0; $i < $len; $i++) {
     $ret_str .= $char;
   }
   return $ret_str;
@@ -2175,7 +2175,7 @@ sub monocharacterString {
   Title    : padString
   Incept   : EPN, Mon Mar 24 13:56:56 2014
   Usage    : padString($orig_str, $tot_len, $pad_char)
-  Function : Return a string that is of total length $tot_len and composed of $orig_str 
+  Function : Return a string that is of total length $tot_len and composed of $orig_str
            : appended with repeating $padchar.
   Args     : $orig_str:  original string
            : $tot_len:   desired length
@@ -2184,12 +2184,12 @@ sub monocharacterString {
 
 =cut
 
-sub padString { 
+sub padString {
   my ($orig_str, $tot_len, $pad_char) = @_;
 
   my $ret_str = $orig_str;
   my $nadd = $tot_len - length($orig_str);
-  if($nadd > 0) { 
+  if($nadd > 0) {
     $nadd /= length($pad_char);
     $ret_str .= Bio::Rfam::Utils::monocharacterString($pad_char, $nadd);
   }
@@ -2235,7 +2235,7 @@ sub percentize {
 sub numLinesInFile {
   my ($filename) = @_;
 
-  open(IN, $filename) || die "ERROR unable to open file $filename in numLinesInFile()"; 
+  open(IN, $filename) || die "ERROR unable to open file $filename in numLinesInFile()";
   my $line_cnt = 0;
 
   while(<IN>) { $line_cnt++; }
@@ -2268,9 +2268,9 @@ sub numLinesInFile {
   Returns  : the md5
 =cut
 
-sub md5_of_sequence_string { 
+sub md5_of_sequence_string {
   my ( $seqstring ) = @_;
-  
+
   $seqstring =~ s/\n//g;     # remove newlines
   $seqstring =~ tr/a-z/A-Z/; # all uppercase
   $seqstring =~ s/U/T/g;     # all DNA
@@ -2282,7 +2282,7 @@ sub md5_of_sequence_string {
 =head2 revcomp_sequence_string
   Title    : revcomp_of_sequence_string
   Incept   : EPN, Tue Nov 27 15:01:39 2018
-  Function : Returns the reverse complement DNA sequence of the passed 
+  Function : Returns the reverse complement DNA sequence of the passed
            : in DNA/RNA sequence string.
            : If passed in sequence is RNA, it is converted to DNA before
            : being reverse complemented.
@@ -2290,12 +2290,12 @@ sub md5_of_sequence_string {
   Returns  : the reverse complemented DNA sequence string
 =cut
 
-sub revcomp_sequence_string { 
+sub revcomp_sequence_string {
   my ( $seqstring ) = @_;
-  
+
   # DNA-ize it
   $seqstring =~ s/Uu/Tt/g; # convert to DNA
-  # reverse it 
+  # reverse it
   $seqstring = reverse $seqstring;
   # complement it
   $seqstring =~ tr/ACGTRYMKHBVDacgtrymkhbvd/TGCAYRKMDVBHtgcayrkmdvbh/;
@@ -2321,12 +2321,12 @@ sub revcomp_sequence_string {
 
 sub rfamseq_nse_lookup_and_md5 {
   my ( $seqDBObj, $nse) = @_;
-  
+
   my ( $is_nse, $name, $start, $end, $strand ) = Bio::Rfam::Utils::nse_breakdown($nse);
-  if(! $is_nse) { 
+  if(! $is_nse) {
     die "ERROR, in rfamseq_nse_lookup_and_md5() $nse not in name/start-end format.\n";
   }
-  
+
   my $have_source_seq = $seqDBObj->check_seq_exists($name) ? 1 : 0;
   my $have_sub_seq    = $seqDBObj->check_subseq_exists($name, $start, $end) ? 1 : 0;
   my $md5 = undef;
@@ -2353,9 +2353,9 @@ sub rfamseq_nse_lookup_and_md5 {
 
 sub ena_nse_lookup_and_md5 {
   my ( $nse ) = @_;
-  
+
   my ( $is_nse, $name, $start, $end, $strand ) = Bio::Rfam::Utils::nse_breakdown($nse);
-  if(! $is_nse) { 
+  if(! $is_nse) {
     die "ERROR, in ena_nse_lookup_and_md5() $nse not in name/start-end format.\n";
   }
   # $nse will have end < start if it is negative strand, but we can't fetch from ENA
@@ -2366,7 +2366,7 @@ sub ena_nse_lookup_and_md5 {
   my $qlen   = abs($start - $end) + 1;
 
   my $url = sprintf("http://www.ebi.ac.uk/ena/data/view/%s&display=fasta&range=%d-%d\"", $name, $qstart, $qend);
-  
+
   my $got_url = get($url);
   my $have_source_seq = ($got_url =~ m/\>/) ? 1 : 0;
   # if we a sequence named $name exists in ENA, $got_url will have a fasta header line
@@ -2378,15 +2378,15 @@ sub ena_nse_lookup_and_md5 {
 
   # it is possible that our coords were out of bounds of the ENA seq.
   # We can detect this if $got_url has nothing but a header line
-  if($have_source_seq) { 
+  if($have_source_seq) {
     my @got_url_A = split(/\n/, $got_url);
-    foreach my $got_url_line (@got_url_A) { 
-      if($got_url_line !~ m/^\>/) { 
+    foreach my $got_url_line (@got_url_A) {
+      if($got_url_line !~ m/^\>/) {
         $sqstring .= $got_url_line;
       }
     }
     if($sqstring ne "") { # $got_url had some sequence, so coords were valid
-      $have_sub_seq = 1; 
+      $have_sub_seq = 1;
       my $sqlen = length($sqstring);
       # Sometimes we fetch the full sequence, sometimes we only fetch the subseq.
       # (I'm not sure how that is determined.) To deal with this, we check if
@@ -2413,7 +2413,7 @@ sub ena_nse_lookup_and_md5 {
            : $nattempts: number of attempts to make to fetch the sequence
            :             (if this is being run in parallel it can cause failure
            :              due (presumably) to overloading NCBI in some way.)
-           :             can be undef, in which case set to '1' 
+           :             can be undef, in which case set to '1'
            : $nseconds:  number of seconds to wait between attempts
            :             can be undef, in which case set to '3'
   Returns  : 3 values:
@@ -2425,9 +2425,9 @@ sub ena_nse_lookup_and_md5 {
 
 sub genbank_nse_lookup_and_md5 {
   my ( $nse, $nattempts, $nseconds ) = @_;
-  
+
   my ( $is_nse, $name, $start, $end, $strand ) = Bio::Rfam::Utils::nse_breakdown($nse);
-  if(! $is_nse) { 
+  if(! $is_nse) {
     die "ERROR, in genbank_nse_lookup_and_md5() $nse not in name/start-end format.\n";
   }
   if(! defined $nattempts) { $nattempts = 1; }
@@ -2451,8 +2451,8 @@ sub genbank_nse_lookup_and_md5 {
   my $got_url = get($url);
   my $looks_like_rnacentral = id_looks_like_rnacentral($name);
 
-  if(! defined $got_url) { 
-    if(! $looks_like_rnacentral) { 
+  if(! defined $got_url) {
+    if(! $looks_like_rnacentral) {
       # if NCBI is being hit by a bunch of requests, the get() command
       # may fail in that $got_url may be undefined. If that happens we
       # wait a few seconds ($nseconds) and try again (up to
@@ -2460,46 +2460,46 @@ sub genbank_nse_lookup_and_md5 {
       # don't look like they are RNAcentral ids. For sequences that
       # look like they are RNAcentral ids we do not do more attempts.
       my $attempt_ctr = 1;
-      while((! defined $got_url) && ($attempt_ctr < $nattempts)) { 
+      while((! defined $got_url) && ($attempt_ctr < $nattempts)) {
         sleep($nseconds);
         $got_url = get($url);
         $attempt_ctr++;
       }
       if(($attempt_ctr >= $nattempts) && (! defined $got_url)) {
-        croak "ERROR trying to fetch sequence info for $name from genbank, reached maximum allowed number of attempts ($nattempts)"; 
+        croak "ERROR trying to fetch sequence info for $name from genbank, reached maximum allowed number of attempts ($nattempts)";
       }
     }
   }
-  elsif($got_url !~ m/^>/) { 
+  elsif($got_url !~ m/^>/) {
     # this shouldn't happen, if the sequence doesn't exist then $got_url should be undefined
-    die "ERROR in genbank_nse_lookup_and_md5() get() returned a value that is not a sequence"; 
+    die "ERROR in genbank_nse_lookup_and_md5() get() returned a value that is not a sequence";
   }
-  else { 
+  else {
     # if we get here: we know that $got_url is defined and starts with a ">",
     # so we know that a sequence named $name exists in GenBank
-    $have_source_seq = 1; 
+    $have_source_seq = 1;
 
     # the fetched sequence should have a header line with a name in this format:
     # >$name:$qstart-$qend
     # if this is not the case, then either the sequence start or end were out of bounds
     # (longer than the sequence length of the fetched sequence)
     my @got_url_A = split(/\n/, $got_url);
-    foreach my $got_url_line (@got_url_A) { 
-      if($got_url_line =~ /^>(\S+)\:(\d+)\-(\d+)/) { 
+    foreach my $got_url_line (@got_url_A) {
+      if($got_url_line =~ /^>(\S+)\:(\d+)\-(\d+)/) {
         my ($fetched_name, $fetched_qstart, $fetched_qend) = ($1, $2, $3);
-        if(($fetched_name   eq $name) && 
-           ($fetched_qstart == $qstart) && 
-           ($fetched_qend   == $qend)) { 
-          $successful_fetch = 1; 
+        if(($fetched_name   eq $name) &&
+           ($fetched_qstart == $qstart) &&
+           ($fetched_qend   == $qend)) {
+          $successful_fetch = 1;
         }
       }
       elsif($got_url_line =~ m/\S/) { # not the header line, not a blank line
         $sqstring .= $got_url_line;
       }
     }
-    if(($successful_fetch) && ($sqstring ne "") && (length($sqstring) == $qlen)) { 
+    if(($successful_fetch) && ($sqstring ne "") && (length($sqstring) == $qlen)) {
       # we fetched the (sub)sequence, coords were valid
-      $have_sub_seq = 1; 
+      $have_sub_seq = 1;
       if($strand != 1) { # negative strand, reverse complement it
         $sqstring = revcomp_sequence_string($sqstring);
       }
@@ -2517,12 +2517,12 @@ sub genbank_nse_lookup_and_md5 {
   Incept   : EPN, Tue Apr 30 20:35:00 2019
   Function : Looks up sequences in GenBank and parses their taxids.
   Args     : $name_AR:   ref to array of names to fetch taxids for, pre-filled
-           : $info_HHR:  ref to 2D hash to fill, 1D key is name from name_AR, 
+           : $info_HHR:  ref to 2D hash to fill, 1D key is name from name_AR,
            :             2D keys are "ncbi_id", "description", "length", and "mol_type"
            : $nattempts: number of attempts to make to fetch the sequence
            :             (if this is being run in parallel it can cause failure
            :              due (presumably) to overloading NCBI in some way.)
-           :             can be undef, in which case set to '1' 
+           :             can be undef, in which case set to '1'
            : $nseconds:  number of seconds to wait between attempts
            :             can be undef, in which case set to '3'
   Returns  : void, fills %{$info_HHR}
@@ -2534,22 +2534,22 @@ sub genbank_fetch_seq_info {
   my ( $name_AR, $info_HHR, $nattempts, $nseconds ) = @_;
 
   my $sub_name = "genbank_fetch_seq_info";
-  
+
   if(! defined $nattempts) { $nattempts = 10; }
   if(! defined $nseconds)  { $nseconds  = 3; }
 
-  if((! defined $name_AR) || (scalar(@{$name_AR}) == 0)) { 
-    croak "ERROR in $sub_name undefined or empty input name array"; 
+  if((! defined $name_AR) || (scalar(@{$name_AR}) == 0)) {
+    croak "ERROR in $sub_name undefined or empty input name array";
   }
-  if(! defined $info_HHR) { 
+  if(! defined $info_HHR) {
     croak "ERROR in $sub_name undefined info_HHR";
   }
 
   # for each sequence, fetch it's info from GenBank, we do this separately to avoid
   # the need to fetch a huge xml string/file
-  foreach my $name (@{$name_AR}) { 
+  foreach my $name (@{$name_AR}) {
     # initialize, and also determine if the sequence name looks
-    # like RNAcentral IDs, if so, we don't expect the GenBank query to 
+    # like RNAcentral IDs, if so, we don't expect the GenBank query to
     # fetch anything
     my $name_str = $name;
     my $looks_like_rnacentral = id_looks_like_rnacentral($name) ? 1 : 0;
@@ -2563,7 +2563,7 @@ sub genbank_fetch_seq_info {
     # printf("Trying to fetch for $name\n");
     my $xml_string = get($genbank_url);
     my $xml_valid = 0;
-    if(defined $xml_string) { 
+    if(defined $xml_string) {
       # to save memory, remove sequence info from the xml_string since we don't need it
       # remove <GBSeq_sequence> lines
       $xml_string =~ s/[^\n]+\<GBSeq\_sequence\>\w+\<\/GBSeq\_sequence\>\n//g;
@@ -2574,19 +2574,19 @@ sub genbank_fetch_seq_info {
       else   { $xml_valid = 1; }
     }
 
-    if(! $xml_valid) { 
-      if(! $looks_like_rnacentral) { 
+    if(! $xml_valid) {
+      if(! $looks_like_rnacentral) {
         # the get() command either failed (returned undef) or
         # returned an invalid xml string, either way we
         # wait a few seconds ($nseconds) and try again (up to
-        # $nattempts) times BUT we only do this if the ID doesn't look 
+        # $nattempts) times BUT we only do this if the ID doesn't look
         # like a RNAcentral ids. If it does, we do not do more attempts.
         my $attempt_ctr = 1;
-        while((! $xml_valid) && ($attempt_ctr < $nattempts)) { 
+        while((! $xml_valid) && ($attempt_ctr < $nattempts)) {
           sleep($nseconds);
           # printf("Retrying to fetch for $name\n");
           $xml_string = get($genbank_url);
-          if(defined $xml_string) { 
+          if(defined $xml_string) {
             # to save memory, remove sequence info from the xml_string since we don't need it
             # remove <GBSeq_sequence> lines
             $xml_string =~ s/[^\n]+\<GBSeq\_sequence\>\w+\<\/GBSeq\_sequence\>\n//g;
@@ -2598,31 +2598,31 @@ sub genbank_fetch_seq_info {
           }
           $attempt_ctr++;
         }
-        if(($attempt_ctr >= $nattempts) && (! $xml_valid)) { 
-          croak "ERROR trying to fetch sequence data for sequence $name from genbank, reached maximum allowed number of attempts ($attempt_ctr)"; 
+        if(($attempt_ctr >= $nattempts) && (! $xml_valid)) {
+          croak "ERROR trying to fetch sequence data for sequence $name from genbank, reached maximum allowed number of attempts ($attempt_ctr)";
         }
       }
     }
-    else { 
+    else {
       # if we get here: we know that $xml_string is defined and valid
       # and $xml is ready for parsing
-      foreach my $gbseq ($xml->findnodes('//GBSeq')) { 
+      foreach my $gbseq ($xml->findnodes('//GBSeq')) {
         my $accver = $gbseq->findvalue('./GBSeq_accession-version');
-        if(! defined $accver) { 
-          croak "ERROR in $sub_name problem parsing XML, no accession-version read"; 
+        if(! defined $accver) {
+          croak "ERROR in $sub_name problem parsing XML, no accession-version read";
         }
-        if(! exists $info_HHR->{$accver}) { 
-          croak "ERROR in $sub_name problem parsing XML, unexpected accession.version $accver"; 
+        if(! exists $info_HHR->{$accver}) {
+          croak "ERROR in $sub_name problem parsing XML, unexpected accession.version $accver";
         }
-        
+
         my $description = $gbseq->findvalue('./GBSeq_definition');
-        if(! defined $description) { 
-          croak "ERROR in $sub_name problem parsing XML, no definition (description) read"; 
+        if(! defined $description) {
+          croak "ERROR in $sub_name problem parsing XML, no definition (description) read";
         }
         $info_HHR->{$accver}{"description"} = $description;
-        
+
         my $length = $gbseq->findvalue('./GBSeq_length');
-        if(! defined $length) { 
+        if(! defined $length) {
           croak "ERROR in $sub_name problem parsing XML, no length read";
         }
         $info_HHR->{$accver}{"length"} = $length;
@@ -2632,21 +2632,21 @@ sub genbank_fetch_seq_info {
         my $taxid_val = $gbseq->findvalue('./GBSeq_feature-table/GBFeature/GBFeature_quals/GBQualifier/GBQualifier_value[starts-with(text(), "taxon:")]');
         my $taxid = undef;
         my $orig_taxid_val = $taxid_val;
-        if(! defined $taxid_val) { 
+        if(! defined $taxid_val) {
           croak "ERROR in $sub_name did not read taxon info for $accver";
         }
         # $taxid_val will be concatenation of taxon:<\d+> N >= 1 times, we want to make sure <\d+> is equivalent all N instances
-        while($taxid_val =~ /^taxon\:(\d+)/) { 
+        while($taxid_val =~ /^taxon\:(\d+)/) {
           my $cur_taxid = $1;
           if(! defined $taxid) { # first taxid
-            $taxid = $cur_taxid; 
+            $taxid = $cur_taxid;
           }
-          elsif($cur_taxid != $taxid) { 
+          elsif($cur_taxid != $taxid) {
             croak "ERROR in $sub_name for $accver, > 1 taxids read: $taxid and $cur_taxid\nFull taxon values read: $orig_taxid_val\n";
           }
           $taxid_val =~ s/^taxon\:(\d+)//;
         }
-        if($taxid_val ne "") { 
+        if($taxid_val ne "") {
           croak "ERROR in $sub_name could not parse taxon info $accver\nFull taxon values read: $orig_taxid_val\n";
         }
         $info_HHR->{$accver}{"ncbi_id"} = $taxid;
@@ -2654,32 +2654,32 @@ sub genbank_fetch_seq_info {
         # mol_type is like taxid in that we may fetch more than one value concatenated together
         # but more complicated because we don't have the 'taxon:' at the beginning to use to parse
         # to determine the single value that we want
-        # For example if we have more than 3 mol_type qualifiers, they will just be concatenated 
+        # For example if we have more than 3 mol_type qualifiers, they will just be concatenated
         # together like "genomic DNAgenomic DNAgenomic DNA" and the single value we want is
         # "genomic DNA". To figure out the single value we assume it is repeated N times,
-        # determine N, then determine its length, use substr to get it, and then verify 
+        # determine N, then determine its length, use substr to get it, and then verify
         # we have that same single value concatenated N times.
         my $mol_type_val = $gbseq->findvalue('./GBSeq_feature-table/GBFeature/GBFeature_quals/GBQualifier/GBQualifier_name[text()="mol_type"]/following-sibling::GBQualifier_value');
         my $mol_type = undef;
         my $orig_mol_type_val = $mol_type_val;
         my $nmol_type = $gbseq->findvalue('count(./GBSeq_feature-table/GBFeature/GBFeature_quals/GBQualifier/GBQualifier_name[text()="mol_type"]/following-sibling::GBQualifier_value)');
         # the value we want ($mol_type) is concatenated $nmol_type times together in $mol_type_val, determine what it is, croaking if we can't
-        if((length($mol_type_val) % ($nmol_type)) != 0) { 
+        if((length($mol_type_val) % ($nmol_type)) != 0) {
           croak "ERROR in $sub_name could not parse mol_type info $mol_type_val\n";
         }
         my $mol_type_len = int((length($mol_type_val) / $nmol_type) + 0.01);
         my $mol_type_val_start = 0;
-        while($mol_type_val_start < $mol_type_len) { 
+        while($mol_type_val_start < $mol_type_len) {
           my $cur_mol_type = substr($mol_type_val, $mol_type_val_start, $mol_type_len);
-          if(! defined $mol_type) { 
-            $mol_type = $cur_mol_type; 
+          if(! defined $mol_type) {
+            $mol_type = $cur_mol_type;
           }
-          elsif($cur_mol_type ne $mol_type) { 
+          elsif($cur_mol_type ne $mol_type) {
             croak "ERROR in $sub_name for $accver, > 1 mol_types read: $mol_type and $cur_mol_type\nFull mol_type values read: $orig_mol_type_val\n";
           }
           $mol_type_val_start += $mol_type_len;
         }
-        if($mol_type_val_start != $mol_type_len) { 
+        if($mol_type_val_start != $mol_type_len) {
           croak "ERROR in $sub_name could not parse mol_type value for $accver\nFull mol_type values read: $orig_mol_type_val\n";
         }
         $info_HHR->{$accver}{"mol_type"} = $mol_type;
@@ -2702,7 +2702,7 @@ sub genbank_fetch_seq_info {
            : $nattempts:     number of attempts to make to fetch the sequence
            :                 (if this is being run in parallel it can cause failure
            :                 due (presumably) to overloading NCBI in some way.)
-           :                 can be undef, in which case set to '1' 
+           :                 can be undef, in which case set to '1'
            : $nseconds:      number of seconds to wait between attempts
            :                 can be undef, in which case set to '3'
   Returns  : void
@@ -2718,124 +2718,124 @@ sub ncbi_taxonomy_fetch_taxinfo {
   if(! defined $nattempts) { $nattempts = 10; }
   if(! defined $nseconds)  { $nseconds  = 3;  }
 
-  if((! defined $taxid_AR) || (scalar(@{$taxid_AR}) == 0)) { 
-    croak "ERROR in $sub_name undefined or empty input name array"; 
+  if((! defined $taxid_AR) || (scalar(@{$taxid_AR}) == 0)) {
+    croak "ERROR in $sub_name undefined or empty input name array";
   }
   my %taxid_H = (); # hash to keep track of the taxids in our input @{$taxid_AR}
-  foreach my $taxid (@{$taxid_AR}) { 
-    if(! defined $taxid_H{$taxid}) { 
+  foreach my $taxid (@{$taxid_AR}) {
+    if(! defined $taxid_H{$taxid}) {
       $taxid_H{$taxid} = 1;
     }
   }
-  
+
   # look up each taxid separately to avoid problem with fetching too many taxids (limit seems to be somewhere around 1000)
-  foreach my $taxid (sort keys (%taxid_H)) { 
+  foreach my $taxid (sort keys (%taxid_H)) {
     my $genbank_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=taxonomy&retmode=xml&id=" . $taxid;
     my $xml = undef;
     my $xml_string = get($genbank_url);
     my $xml_valid = 0;
-    if(defined $xml_string) { 
+    if(defined $xml_string) {
       $xml = eval { XML::LibXML->load_xml(string => $xml_string); };
       if($@) { $xml_valid = 0; }
       else   { $xml_valid = 1; }
     }
-    
-    if(! $xml_valid) { 
+
+    if(! $xml_valid) {
       # the get() command either failed (returned undef) or
       # returned an invalid xml string, either way we
       # wait a few seconds ($nseconds) and try again (up to
-      # $nattempts) times BUT we only do this if the ID doesn't look 
+      # $nattempts) times BUT we only do this if the ID doesn't look
       # like a RNAcentral ids. If it does, we do not do more attempts.
       my $attempt_ctr = 1;
-      while((! $xml_valid) && ($attempt_ctr < $nattempts)) { 
+      while((! $xml_valid) && ($attempt_ctr < $nattempts)) {
         sleep($nseconds);
         $xml_string = get($genbank_url);
-        if(defined $xml_string) { 
+        if(defined $xml_string) {
           $xml = eval { XML::LibXML->load_xml(string => $xml_string); };
           if($@) { $xml_valid = 0; }
           else   { $xml_valid = 1; }
         }
         $attempt_ctr++;
       }
-      if(($attempt_ctr >= $nattempts) && (! $xml_valid)) { 
-        croak "ERROR trying to fetch taxids from genbank, reached maximum allowed number of failed attempts ($nattempts)\nList of taxids:\n$taxid\n"; 
+      if(($attempt_ctr >= $nattempts) && (! $xml_valid)) {
+        croak "ERROR trying to fetch taxids from genbank, reached maximum allowed number of failed attempts ($nattempts)\nList of taxids:\n$taxid\n";
       }
     }
-    
-    foreach my $taxon ($xml->findnodes('/TaxaSet/Taxon')) { 
+
+    foreach my $taxon ($xml->findnodes('/TaxaSet/Taxon')) {
       my $cur_taxid = $taxon->findvalue('./TaxId');
-      if(! defined $cur_taxid) { 
+      if(! defined $cur_taxid) {
         croak "ERROR in $sub_name unable to parse taxid from xml";
       }
       # check if there are any additional taxids:
       my @aka_taxid_A = ();
-      foreach my $aka_taxid_node ($taxon->findnodes('./AkaTaxIds/TaxId')) { 
+      foreach my $aka_taxid_node ($taxon->findnodes('./AkaTaxIds/TaxId')) {
         push(@aka_taxid_A, $aka_taxid_node->to_literal());
       }
       # Determine which input taxid this xml set pertains to.
       # It is not necessarily $cur_taxid (because if input taxid has been merged
       # with another taxid, then $cur_taxid will be the new taxid it was merged to).
       # However, if $cur_taxid is not an input taxid, one of the ids in @aka_taxid_A
-      # should be. 
+      # should be.
       my $taxid = undef;
       my $taxid_is_cur = 0; # the taxid we wanted to fetch we actually fetched (we didn't fetch a new taxid that was merged to the one we wanted)
-      if(defined $taxid_H{$cur_taxid}) { 
+      if(defined $taxid_H{$cur_taxid}) {
         $taxid = $cur_taxid;
         $taxid_is_cur = 1;
       }
-      else { 
-        foreach my $aka_taxid (@aka_taxid_A) { 
-          if((! defined $taxid) && (defined $taxid_H{$aka_taxid})) { 
+      else {
+        foreach my $aka_taxid (@aka_taxid_A) {
+          if((! defined $taxid) && (defined $taxid_H{$aka_taxid})) {
             $taxid = $aka_taxid;
           }
         }
       }
-      if(! defined $taxid) { 
+      if(! defined $taxid) {
         croak ("ERROR in $sub_name, unable to determine matching input tax id for fetched taxid $cur_taxid");
       }
-      
+
       my $lineage = $taxon->findvalue('./Lineage');
-      if(! defined $lineage) { 
+      if(! defined $lineage) {
         croak "ERROR in $sub_name unable to parse lineage from xml for taxid $cur_taxid";
       }
-      
+
       my $scientific_name = $taxon->findvalue('./ScientificName');
-      if(! defined $scientific_name) { 
+      if(! defined $scientific_name) {
         croak "ERROR in $sub_name unable to parse scientific_name from xml for taxid $cur_taxid";
       }
-      
+
       my $genbank_common_name = $taxon->findvalue('./OtherNames/GenbankCommonName');
       my $species = sprintf("%s%s", $scientific_name, (defined $genbank_common_name) ? " ($genbank_common_name)" : "");
-      
+
       my $tree_display_name = $species;
       $tree_display_name =~ s/ /\_/g;
 
       my $align_display_name = $tree_display_name . "[" . $taxid . "]";
-      
+
       # we only want the lineage starting at "superkingdom", so we have to parse further
       my @lineage_A = split("; ", $lineage);
       my $i = 0;
       my $superkingdom_i = -1;
-      foreach my $sub_taxon ($taxon->findnodes('./LineageEx/Taxon')) { 
+      foreach my $sub_taxon ($taxon->findnodes('./LineageEx/Taxon')) {
         my $sub_scientific_name = $sub_taxon->findvalue('./ScientificName');
         my $sub_rank = $sub_taxon->findvalue('./Rank');
-        if($sub_rank eq "superkingdom") { 
+        if($sub_rank eq "superkingdom") {
           $superkingdom_i = $i;
         }
         $i++;
       }
       my $tax_string = "Unclassified"; # overwritten below if we read LineageEx/Taxon info into @lineage_A
-      if($superkingdom_i != -1) { 
+      if($superkingdom_i != -1) {
         $tax_string = join("; ", splice(@lineage_A, $superkingdom_i));
       }
-      # commented out this check: could be 'unclassified sequences' or 'marine metagenome' or maybe others? 
-      # this check used to verify it was an expected species value, but I commented it out because I 
+      # commented out this check: could be 'unclassified sequences' or 'marine metagenome' or maybe others?
+      # this check used to verify it was an expected species value, but I commented it out because I
       # didn't want to need to list them all
-      #elsif($species !~ /^unclassified sequences/) { # could also 
+      #elsif($species !~ /^unclassified sequences/) { # could also
       #  croak "ERROR in $sub_name unable to find superkingdom rank for taxid $taxid and species is not 'unclassified sequences' but '$species'";
       #}
-      
-      if(($taxid_is_cur) || (! defined $tax_table_HHR->{$taxid})) { 
+
+      if(($taxid_is_cur) || (! defined $tax_table_HHR->{$taxid})) {
         %{$tax_table_HHR->{$taxid}} = ();
         $tax_table_HHR->{$taxid}{"species"}            = $species;
         $tax_table_HHR->{$taxid}{"tax_string"}         = $tax_string;
@@ -2863,9 +2863,9 @@ sub ncbi_taxonomy_fetch_taxinfo {
   Dies     : if there is a problem fetching from RNAcentral
 =cut
 
-sub rnacentral_md5_lookup { 
+sub rnacentral_md5_lookup {
   my ( $in_md5 ) = @_;
-  
+
   my $rnacentral_url = "https://rnacentral.org/api/v1/rna?md5=" . $in_md5;
   #printf("rnacentral_url: $rnacentral_url\n");
   my $json = get($rnacentral_url);
@@ -2879,8 +2879,8 @@ sub rnacentral_md5_lookup {
   my $id   = undef;
   my $desc = undef;
 
-  if((defined $decoded_json->{'results'}) && 
-     (defined $decoded_json->{'results'}[0]{'md5'}) && 
+  if((defined $decoded_json->{'results'}) &&
+     (defined $decoded_json->{'results'}[0]{'md5'}) &&
      (defined $decoded_json->{'results'}[0]{'rnacentral_id'})) {
     $have_seq = 1;
     $md5  = $decoded_json->{'results'}[0]{'md5'};
@@ -2906,9 +2906,9 @@ sub rnacentral_md5_lookup {
   Dies     : if there is a problem fetching from RNAcentral
 =cut
 
-sub rnacentral_id_lookup { 
+sub rnacentral_id_lookup {
   my ( $in_id ) = @_;
-  
+
   my $rnacentral_url = "https://rnacentral.org/api/v1/rna?rnacentral_id5=" . $in_id;
   #printf("rnacentral_url: $rnacentral_url\n");
   my $json = get($rnacentral_url);
@@ -2922,8 +2922,8 @@ sub rnacentral_id_lookup {
   my $desc   = undef;
   my $length = undef;
 
-  if((defined $decoded_json->{'results'}) && 
-     (defined $decoded_json->{'results'}[0]{'md5'}) && 
+  if((defined $decoded_json->{'results'}) &&
+     (defined $decoded_json->{'results'}[0]{'md5'}) &&
      (defined $decoded_json->{'results'}[0]{'rnacentral_id'})) {
     $have_seq = 1;
     $md5    = $decoded_json->{'results'}[0]{'md5'};
@@ -2939,15 +2939,15 @@ sub rnacentral_id_lookup {
   Incept   : EPN, Fri Feb 22 16:24:58 2019
   Function : Returns '1' if $id 'looks like' a RNAcentral ID
   Args     : $id: sequence name
-  Returns  : '1' if $id 'looks like' it is from RNAcetnral 
+  Returns  : '1' if $id 'looks like' it is from RNAcetnral
            : '0' if it does not
 =cut
 
-sub id_looks_like_rnacentral { 
+sub id_looks_like_rnacentral {
   my ( $id ) = @_;
 
-  if($id =~ /^URS[0-9A-F]{10}/) { 
-    return 1; 
+  if($id =~ /^URS[0-9A-F]{10}/) {
+    return 1;
   }
   return 0;
 }
@@ -2960,7 +2960,7 @@ sub id_looks_like_rnacentral {
   Usage    : rnacentral_urs_taxid_breakdown($rnacentral_id)
   Function : Checks if $rnacentral_id is of format "URS_taxid",
            : where URS matches /^URS[0-9A-F]{10}/ and taxid is
-           : an integer, and breaks it down into $urs, $taxid 
+           : an integer, and breaks it down into $urs, $taxid
            : (see 'Returns' section)
   Args     : <sqname>: seqname, possibly of format "URS_taxid"
   Returns  : 3 values:
@@ -2971,11 +2971,11 @@ sub id_looks_like_rnacentral {
 
 sub rnacentral_urs_taxid_breakdown {
   my ($sqname) = $_[0];
-  
+
   my $urs;    # URS id
   my $taxid;  # taxid
-  
-  if($sqname =~ /^(URS[0-9A-F]{10})\_(\d+)$/) { 
+
+  if($sqname =~ /^(URS[0-9A-F]{10})\_(\d+)$/) {
     ($urs, $taxid) = ($1,$2);
     return(1, $urs, $taxid);
   }
@@ -2989,7 +2989,7 @@ sub rnacentral_urs_taxid_breakdown {
   Incept   : EPN, Fri May 10 17:04:20 2019
   Usage    : accession_version_breakdown($accver)
   Function : Checks if $accver is of format /^\S+\.\d+$/
-           : without checking that accession is actually a 
+           : without checking that accession is actually a
            : valid accession (any string is allowed)
            : and breaks down into accession and version.
            : (see 'Returns' section)
@@ -3002,11 +3002,11 @@ sub rnacentral_urs_taxid_breakdown {
 
 sub accession_version_breakdown {
   my ($sqname) = $_[0];
-  
+
   my $acc;
   my $ver;
-  
-  if($sqname =~ /^(\S+)\.(\d+)$/) { 
+
+  if($sqname =~ /^(\S+)\.(\d+)$/) {
     ($acc, $ver) = ($1,$2);
     return(1, $acc, $ver);
   }
@@ -3019,11 +3019,11 @@ sub accession_version_breakdown {
   Incept   : EPN, Tue Apr 30 21:09:22 2019
   Function : Removes a version from an accession.version string
   Args     : $accver: accession.version
-  Returns  : $accver with version removed, if $accver not in the 
+  Returns  : $accver with version removed, if $accver not in the
            : correct format, just returns what is passed in
 =cut
 
-sub strip_version { 
+sub strip_version {
   my ( $accver ) = @_;
 
   $accver =~ s/\.\d+$//;
@@ -3034,7 +3034,7 @@ sub strip_version {
 #-------------------------------------------------------------------------------
 
 #-------------------------------------------------------------------------------
-# Miniature helper subroutines 
+# Miniature helper subroutines
 #-------------------------------------------------------------------------------
 
 =head2 _max
@@ -3104,7 +3104,3 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 =cut
 
 1;
-
-
-
-

--- a/Rfam/Scripts/jiffies/validate_seed_sequences_against_databases.pl
+++ b/Rfam/Scripts/jiffies/validate_seed_sequences_against_databases.pl
@@ -12,8 +12,8 @@ use Moose;
 
 use Getopt::Long;
 
-my $usage  = "Usage:\nperl test_fetch_seed_seq_info.pl <accession>\nOR\n";
-   $usage .= "perl test_fetch_seed_seq_info.pl -a <alifile>\n";
+my $usage  = "Usage:\nperl validate_seed_sequences_against_databases.pl <accession>\nOR\n";
+   $usage .= "perl validate_seed_sequences_against_databases.pl -a <alifile>\n";
 
 my $acc_or_alifile = undef; # single command line arg
 my $a_opt          = undef; # defined if -a used


### PR DESCRIPTION
Hi Eric @nawrockie!

⚠️ This is not urgent so it can wait until you have time.

We were working on committing new microRNA families and noticed that some SEEDs failed the QC with a message that the sequence was not found in GenBank, Rfamseq, and RNAcentral. 

It turns out that this happens only when the SEED includes a subsequence from an RNAcentral URS id (`URS/start-end` where `start != 1` or `end != length(URS)`. Everything worked fine if the entire RNAcentral sequence was included in the SEED (which has always been the case in the past), but it started failing once we had to adjust the start and end coordinates for importing miRBase.

I added a new routine to check the subsequences and put it higher in the decision tree than your current function. I am not sure if the old routine is necessary anymore - any input will be welcome.

Please review the code and feel free to merge if it's all good (or push any changes to the same branch). This branch is deployed on the EBI cluster for testing. You can find some examples in the `#rfam` Slack channel. Thank you!

PS. Only the 5700b79 commit is meaningful. In the other commit I removed some trailing whitespace.