### PR TITLE
Changes cmalign_wrapper to allow specification of MPI/non-MPI

### DIFF
--- a/Rfam/Scripts/jiffies/rewrite_seed_with_rf.pl
+++ b/Rfam/Scripts/jiffies/rewrite_seed_with_rf.pl
@@ -574,7 +574,7 @@ sub verify_cm_built_from_seed {
   else { 
     $unlink_stkfile = 0;
   }
-  Bio::Rfam::Infernal::cmalign_wrapper($config, "", "", "--mapali $seedfile -o $stkfile", "CM", $fafile, undef, "", 1, 100, 1, 0, "", 1, undef, 0);
+  Bio::Rfam::Infernal::cmalign_wrapper($config, "", "", "--mapali $seedfile -o $stkfile", "CM", $fafile, undef, "", 1, 100, 1, 0, 0, "", 1, undef, 0);
   # we'll die if $seedfile wasn't used to build $cmfile
 
   unlink $fafile;

--- a/Rfam/Scripts/make/rfmatch.pl
+++ b/Rfam/Scripts/make/rfmatch.pl
@@ -250,7 +250,7 @@ my $stk_file     = "$$.stk";
 my $err_file     = "a.$$.err";
 my $align_opts = "-o $stk_file --noprob"; # PPs will just increase size of file -- we won't use them
 if(! $do_local) { $align_opts .= " -g"; }
-Bio::Rfam::Infernal::cmalign_wrapper($config, $user, "a.$$", $align_opts, "CM", $fa_file, $cmalign_file, "a.$$.err", $nhit + $nmatch, $nhit_res + $nmatch_res, 1, 0, "", -1, $logFH, 1);
+Bio::Rfam::Infernal::cmalign_wrapper($config, $user, "a.$$", $align_opts, "CM", $fa_file, $cmalign_file, "a.$$.err", $nhit + $nmatch, $nhit_res + $nmatch_res, 1, 0, 0, "", -1, $logFH, 1);
 push(@unlinkA, ($cmalign_file, $err_file, $fa_file, $stk_file));
 
 # read in MSA we just created

--- a/Rfam/Scripts/make/rfreplace.pl
+++ b/Rfam/Scripts/make/rfreplace.pl
@@ -538,7 +538,7 @@ sub cmalign_seed_and_hits {
   my $align_opts = "-o $stkfile --noprob"; # PPs will just increase size of file -- we won't use them
   my $cmalign_file = "$$.cmalign";
   if(! $do_local) { $align_opts .= " -g"; }
-  Bio::Rfam::Infernal::cmalign_wrapper($config, $user, "a.$$", $align_opts, "CM", $fafile, "$$.cmalign", "a.$$.err", $nhit, $nhit_res, 1, 0, "", -1, $logFH, 1);
+  Bio::Rfam::Infernal::cmalign_wrapper($config, $user, "a.$$", $align_opts, "CM", $fafile, "$$.cmalign", "a.$$.err", $nhit, $nhit_res, 1, 0, 0, "", -1, $logFH, 1);
   foreach my $file ($cmalign_file) { unlink $file; }
   
   my $msa = Bio::Easel::MSA->new({

--- a/Rfam/Scripts/make/rfsearch.pl
+++ b/Rfam/Scripts/make/rfsearch.pl
@@ -562,7 +562,7 @@ if ($do_build) {
   my $emit_fafile         = "e.$$.fa";
   my $cmalign_mapali_file = "ma.$$.stk";
   Bio::Rfam::Infernal::cmemit_wrapper($config, "-c -o $emit_fafile", $cmfile, undef, 0);
-  Bio::Rfam::Infernal::cmalign_wrapper($config, "", "", "--mapali SEED -o $cmalign_mapali_file", "CM", $emit_fafile, undef, "", 1, 100, 1, 0, "", 1, undef, 0);
+  Bio::Rfam::Infernal::cmalign_wrapper($config, "", "", "--mapali SEED -o $cmalign_mapali_file", "CM", $emit_fafile, undef, "", 1, 100, 1, 0, 0, "", 1, undef, 0);
 
   # add RF annotation from cmalign --mapali output file to original SEED
   # to create a new SEED file 

--- a/Rfam/Scripts/make/rfseed.pl
+++ b/Rfam/Scripts/make/rfseed.pl
@@ -207,7 +207,7 @@ else { # adding seqs
   my $align_opts = "-o SEED --mapali SEED.$$ --mapstr";
   if(! $do_prob)  { $align_opts .= " --noprob"; }
   if(! $do_local) { $align_opts .= " -g"; }
-  Bio::Rfam::Infernal::cmalign_wrapper($config, $user, "a.$$", $align_opts, "CM", $fafile, $cmalign_file, $err_file, $nseq, $nres, 1, 0, "", -1, $logFH, $do_stdout);
+  Bio::Rfam::Infernal::cmalign_wrapper($config, $user, "a.$$", $align_opts, "CM", $fafile, $cmalign_file, $err_file, $nseq, $nres, 1, 0, 0, "", -1, $logFH, $do_stdout);
   push(@unlinkA, ($err_file, $fafile));
 }
 


### PR DESCRIPTION
rfmake.pl with -a or -r now call cmalign without MPI (you can specify MPI with -mpi) and send it to the cluster (similar to how rfsearch uses cmcalibrate). This limits resource use on local host, but you can still run locally with -local.