### PR TITLE
Fixes previous commit (767a1b8) by commenting out substitutions from …

### DIFF
--- a/Rfam/Lib/Bio/Rfam/Utils.pm
+++ b/Rfam/Lib/Bio/Rfam/Utils.pm
@@ -2565,11 +2565,17 @@ sub genbank_fetch_seq_info {
     my $xml_string = get($genbank_url);
     my $xml_valid = 0;
     if(defined $xml_string) {
-      # to save memory, remove sequence info from the xml_string since we don't need it
-      # remove <GBSeq_sequence> lines
-      $xml_string =~ s/[^\n]+\<GBSeq\_sequence\>\w+\<\/GBSeq\_sequence\>\n//g;
-      # remove <GBQualifier>\n<GBQualifer_name>translation\nGBQualifier_value\n<\GBQualifier> sets of 4 lines
-      $xml_string =~ s/[^\n]+\<GBQualifier\>\n[^\n]+\<GBQualifier\_name\>translation\<\/GBQualifier\_name\>\n[^\n]+\<GBQualifier\_value\>\w+\<\/GBQualifier\_value\>\n[^\n]+\<\/GBQualifier\>\n//g;
+      # Previously, we tried to substitute out the GBSeq_sequence and translation lines
+      # but in Sept 2022 this was identified as a bottleneck for at least some families
+      # these substitution commands are now commented out but left here for reference.
+      # The motivation for them in the first place was to save memory so if memory
+      # does not become an issue it should be fine to leave them commented out:
+      # --------------
+      ## to save memory, remove sequence info from the xml_string since we don't need it
+      ## remove <GBSeq_sequence> lines
+      #$xml_string =~ s/[^\n]+\<GBSeq\_sequence\>\w+\<\/GBSeq\_sequence\>\n//g;
+      ## remove <GBQualifier>\n<GBQualifer_name>translation\nGBQualifier_value\n<\GBQualifier> sets of 4 lines
+      #$xml_string =~ s/[^\n]+\<GBQualifier\>\n[^\n]+\<GBQualifier\_name\>translation\<\/GBQualifier\_name\>\n[^\n]+\<GBQualifier\_value\>\w+\<\/GBQualifier\_value\>\n[^\n]+\<\/GBQualifier\>\n//g;
       $xml = eval { XML::LibXML->load_xml(string => $xml_string); };
       if($@) { $xml_valid = 0; }
       else   { $xml_valid = 1; }
@@ -2588,11 +2594,8 @@ sub genbank_fetch_seq_info {
           # printf("Retrying to fetch for $name\n");
           $xml_string = get($genbank_url);
           if(defined $xml_string) {
-            # Previously, we tried to substitute out the GBSeq_sequence and translation lines
-            # but in Sept 2022 this was identified as a bottleneck for at least some families
-            # these substitution commands are now commented out but left here for reference.
-            # The motivation for them in the first place was to save memory so if memory
-            # does not become an issue it should be fine to leave them commented out:
+            # Two substitions below are commented out, see comment above
+            # in analogous position (search for 'Sept 2022')
             # --------------
             ## to save memory, remove sequence info from the xml_string since we don't need it
             ## remove <GBSeq_sequence> lines


### PR DESCRIPTION
Code in previous PR#84 mistakenly only commented out substitution calls in xml_string in attempts #2 to N, this commit also comments out the same substitution calls in attempt #1. 