### PR TITLE
FOR DISCUSSION: check rfamlive for seed info to remove need for some NCBI fetching

### DIFF
--- a/Rfam/Lib/Bio/Rfam/FamilyIO.pm
+++ b/Rfam/Lib/Bio/Rfam/FamilyIO.pm
@@ -4094,7 +4094,7 @@ sub fetch_seed_sequence_info {
   }
 
   if(scalar(@lookup_genbank_A) > 0) { 
-    Bio::Rfam::Utils::genbank_fetch_seq_info(\@lookup_genbank_A, \%seed_name_info_HH);
+    Bio::Rfam::Utils::genbank_fetch_seq_info(\@lookup_genbank_A, \%seed_name_info_HH, 200, 3);
   }
 
   foreach $seed_name (@seed_name_A) { 

--- a/Rfam/Lib/Bio/Rfam/FamilyIO.pm
+++ b/Rfam/Lib/Bio/Rfam/FamilyIO.pm
@@ -4028,16 +4028,16 @@ sub validate_species_format {
 
   Title    : fetch_seed_sequence_info
   Incept   : EPN, Wed May  8 15:08:06 2019
-  Usage    : Bio::Rfam::FamilyIO::fetch_seed_sequence_info($seed_name_AR, $seed_info_HHR)
+  Usage    : Bio::Rfam::FamilyIO::fetch_seed_sequence_info($seed_name_AR, $sthRfamseqSeed, $sthTaxSeed, $seed_info_HHR)
   Function : Fetch information on seed sequences in @{$seed_name_AR} from either 
            : the RfamLive DB or NCBI's Genbank/Taxonomy and fill in data in 
            : %{$seed_info_HHR}.
   Args     : $seedmsa:         Bio::Rfam::Family::MSA object, the seed alignment
            : $sthRfamseqSeed:  prepared database query for fetching taxid and seq description from RfamLive Rfamseq table
-           :                   ($rfdbh->prepare_seqaccToTaxIdAndDescAndLengthription())
+           :                   ($rfdbh->prepare_seqaccToTaxIdAndDescLengthMolTypeAndSource())
            :                   undef to NOT try to fetch from RfamLive rfamseq table
            : $sthTaxSeed:      prepared database query for fetching species and tax string from RfamLive taxonomy table
-           :                   ($rfdbh->prepare_taxIdToSpeciesAndTaxString())
+           :                   ($rfdbh->prepare_taxIdToSpeciesDisplayNamesAndTaxString())
            :                   undef to NOT try to fetch from RfamLive taxonomy table
            : $seed_info_HHR:   ref to 2D hash with seed info, FILLED HERE
            :                   1D key is seed name (name/start-end), 2D keys are:

--- a/Rfam/Lib/Bio/Rfam/SVN/Commit.pm
+++ b/Rfam/Lib/Bio/Rfam/SVN/Commit.pm
@@ -191,11 +191,16 @@ sub _commitEntry {
     $self->{logger}->debug( 'only the DESC file was changed' );
   }else{
     #There is more to change than just the DESC file....
-    # fetch current info for the SEED seqs from GenBank/Rnacentral
+    # fetch current info for the SEED seqs from GenBank/Rnacentral or RfamLive if they're already there
     my %seed_info_HH; # 1D key is seed sequence name (name/start-end format)
                       # 2D keys are many of the field names in Rfamseq and Taxonomy tables 
                       # (see fetch_seed_sequence_info() for details)
-    Bio::Rfam::FamilyIO::fetch_seed_sequence_info($familyObj->SEED, undef, undef, \%seed_info_HH);
+    my $sthRfamseqSeed = $rfamdb->prepare_seqaccToTaxIdDescLengthMolTypeAndSource();
+    my $sthTaxSeed     = $rfamdb->prepare_taxIdToSpeciesDisplayNamesAndTaxString();
+    # we don't fetch data on seqs already in rfamlive, to do that use second call below commented out
+    # below which passes 2nd and 3rd args as undef
+    Bio::Rfam::FamilyIO::fetch_seed_sequence_info($familyObj->SEED, $sthRfamseqSeed, $sthTaxSeed, \%seed_info_HH);
+    #Bio::Rfam::FamilyIO::fetch_seed_sequence_info($familyObj->SEED, undef, undef, \%seed_info_HH); 
     $self->{logger}->debug( 'fetched seed sequence info' );
 
     # order of updates: taxonomy, rfamseq, seed_region, full_region, rnacentral_matches

--- a/Rfam/Scripts/jiffies/test_fetch_seed_seq_info.pl
+++ b/Rfam/Scripts/jiffies/test_fetch_seed_seq_info.pl
@@ -16,13 +16,17 @@ use Bio::Rfam::Utils;
 
 use Getopt::Long;
 
-my $usage  = "Usage:\nperl test_fetch_seed_seq_info.pl <accession>\nOR\n";
-   $usage .= "perl test_fetch_seed_seq_info.pl -a <alifile>\n";
+my $usage  = "Usage:\nperl test_fetch_seed_seq_info.pl <accession>\n";
+$usage  .= "\tOPTIONS:\n";
+$usage  .= "\t-a: input cmdline argument is an <alifile> not <accession>\n";
+$usage  .= "\t-f: force getting info NCBI for all sequences, even those already in RfamLive\n";
 
 my $acc_or_alifile = undef; # single command line arg
 my $a_opt          = undef; # defined if -a used
+my $f_opt          = undef; # defined if -f used
 
-my $options_okay = &GetOptions("a" => \$a_opt);
+my $options_okay = &GetOptions("a" => \$a_opt,
+                               "f" => \$f_opt);
 
 my $exit_early = 0;
 if(! $options_okay) { 
@@ -39,7 +43,8 @@ if($exit_early) {
 }
                                
 $acc_or_alifile = ($ARGV[0]);
-my $do_ali = (defined $a_opt) ? 1 : 0;
+my $do_ali   = (defined $a_opt) ? 1 : 0;
+my $do_force = (defined $f_opt) ? 1 : 0;
 
 print "$acc_or_alifile\n";
 
@@ -48,19 +53,27 @@ select *STDOUT;
 $| = 1;
 
 my $seed = undef;
-if(! $do_ali) { # load from DB
-  my $config = Bio::Rfam::Config->new;
-  my $familyIO = Bio::Rfam::FamilyIO->new;
-  my $rfamdb = $config->rfamlive;
-  my $client = Bio::Rfam::SVN::Client->new({config => $config});
-  my $seqDBObj = $config->rfamseqObj;
+my $config = undef;
+my $familyIO = undef;
+my $rfamdb = undef;
+my $client = undef;
+my $seqDBObj = undef;
 
+# setup the config and db unless -a and -f both used 
+if((! $do_force) || (! $do_ali)) {
+  $config = Bio::Rfam::Config->new;
+  $rfamdb = $config->rfamlive;
+  $familyIO = Bio::Rfam::FamilyIO->new;
+  $client = Bio::Rfam::SVN::Client->new({config => $config});
+  $seqDBObj = $config->rfamseqObj;
+}
+if(! $do_ali) { # load from DB
   #my $familyObj = $familyIO->loadRfamFromSVN($acc_or_alifile, $client);
   my $familyObj = $familyIO->loadRfamFromSVN_preSEED($acc_or_alifile, $client);
   print STDERR "Successfully loaded SVN copy of $acc_or_alifile through middleware\n";
   $seed = $familyObj->SEED;
 }
-else { # -a used
+else { # -a used, load from alignment file
   $seed = Bio::Easel::MSA->new({
     fileLocation => $acc_or_alifile,
     isDna => 1});  
@@ -69,7 +82,15 @@ else { # -a used
 my %seed_info_HH; # 1D key is seed sequence name (name/start-end format)
                   # 2D keys are many of the field names in Rfamseq and Taxonomy tables 
                   # (see fetch_seed_sequence_info() for details)
-Bio::Rfam::FamilyIO::fetch_seed_sequence_info($seed, undef, undef, \%seed_info_HH);
+
+if($do_force) { # -f used, force ncbi fetch of all seqs
+  Bio::Rfam::FamilyIO::fetch_seed_sequence_info($seed, undef, undef, \%seed_info_HH);
+}
+else { # -f not used, only fetch info on seqs not already in rfamlive
+  my $sthRfamseqSeed = $rfamdb->prepare_seqaccToTaxIdDescLengthMolTypeAndSource();
+  my $sthTaxSeed     = $rfamdb->prepare_taxIdToSpeciesDisplayNamesAndTaxString();
+  Bio::Rfam::FamilyIO::fetch_seed_sequence_info($seed, $sthRfamseqSeed, $sthTaxSeed, \%seed_info_HH);
+}
 
 for(my $i = 0; $i < $seed->nseq; $i++) { 
   my $seed_name = $seed->get_sqname($i);

--- a/Rfam/Scripts/jiffies/test_genbank_fetch_seq_info.pl
+++ b/Rfam/Scripts/jiffies/test_genbank_fetch_seq_info.pl
@@ -23,8 +23,6 @@ my %info_HH = ();
 
 Bio::Rfam::Utils::genbank_fetch_seq_info(\@name_A, \%info_HH);
 
-printf("HEYA back from genbank_fetch_seq_info()\n");
-
 exit 0;
 
 


### PR DESCRIPTION
Based on my recent experience with trying to commit some families, I    
think the slowest step for most families is fetching data from          
NCBI. For really large families, the QC steps are also slow and the     
actual svn commit of the large files is also slow.                      
                                                                        
For the NCBI fetching, I think there's at least one way to make it      
somewhat faster, which is the focus of this PR. There are actually two  
separate steps that fetch data from NCBI during a commit.               
                                                                        
1) fetch info for each seed seq from NCBI so that the Rfamseq and       
Taxonomy tables can be updated with the latest information from         
NCBI. To do this, the entire GenBank record in XML format is fetched    
for each sequence. The attributes that are updated are: `ncbi_id`,      
`mol_type`, `length`, `description` and `source` in the Rfamseq table   
and `ncbi_id`, `species`, `tree_display_name`, `align_display_name`     
and `tax_string` in the Taxonomy table.                                 
                                                                        
2) fetch the actual subsequence that each seed sequence pertains to     
from NCBI (or RNAcentral or Rfamseq) e.g. for CP00001.1/30-60,          
nucleotides 30 to 60 from NCBI record CP00001.1 would be fetched.       
The md5 of the fetched sequence is then compared to the md5 of the      
sequence in seed alignment to make sure they are identical.             
                                                                        
Check #1 can take longer than check #2 because the entire record is     
fetched. In my testing, it takes between 2 to 25 seconds per sequence,  
with longer sequences that have more annotation etc. taking longer.     
Check #2 usually takes 1-2 seconds per sequence. There is probably      
some variability related to the load of requests at NCBI too, unless    
the real issue is the download speed - I'm not sure. I did not test at  
different times/dates.                                                  
                                                                        
My opinion is that check #2 is the more important check, as it          
prevents the situation where someone accidentally changed a sequence    
in a SEED file, that would otherwise go live into Rfam if it were not   
caught at the commit step.                                              
                                                                        
But, if you are ok with the information in RfamLive for seed sequences  
possibly becoming out-of-date then I think it is ok to skip check #1    
for any sequences that are already in RfamLive. I think that it is      
actually true that all seed sequences (as of some recent date) are      
already in RfamLive, so this would mean check #1 would become nearly    
instantaneous for all existing families when the seed is unchanged,     
but wouldn't be skipped for new families, or when new seed sequences    
are added to an existing family.                                        
                                                                        
If we did go this route and start skipping check #1, it could be that   
a background script is run to update these tables for all seed          
sequences every so often to keep the seed sequence info in the Rfamseq  
and Taxonomy tables up to date.                                         
                                                                        
This PR includes code changes that have check #1 skipped for any        
sequences already in RfamLive. I'm not sure if you want to actually do  
this, which is why I put "FOR DISCUSSION" at the beginning of the PR    
title. I'm happy to have a slack huddle or zoom call to discuss this    
further if you want.