### PR TITLE
Adds bit scores to output of overlap checking with other families (rfci.pl and rfnew.pl (at least))

### DIFF
--- a/Rfam/Lib/Bio/Rfam/QC.pm
+++ b/Rfam/Lib/Bio/Rfam/QC.pm
@@ -1731,7 +1731,7 @@ sub findExternalOverlaps {
         $r->[1] <= $r->[2] ? ($r->[1], $r->[2], 1) : ($r->[2], $r->[1], -1);
 
     if($currentAcc ne $r->[3]){
-      $regions = $rfamdb->resultset('FullRegion')->regionsByRfamseqAcc($r->[3]);
+      $regions = $rfamdb->resultset('FullRegion')->allRegionInfo($r->[3]);
       $currentAcc=  $r->[3];
     }
     foreach my $dbReg (@$regions){
@@ -1747,11 +1747,13 @@ sub findExternalOverlaps {
           $overlap = 'fullOL' if ( $overlap == -1 );
           my $overlapType =  $dbReg->[4] eq $or1 ? 'SS' : 'OS';
           #TODO Fix reporting when I have information.
-          my $eString = sprintf "External overlap [%s] of %s with %s by %s\n",
-            $overlapType,
-            $r->[0],
-            $dbReg->[1].":".$dbReg->[0]."/".$dbReg->[2]."-".$dbReg->[3],
-            $overlap;
+          my $eString = sprintf "External overlap [%s] of %s (%.2f bits) with %s (%.2f bits) by %s\n",
+              $overlapType,
+              $r->[0],
+              $r->[4], 
+              $dbReg->[1].":".$dbReg->[0]."/".$dbReg->[2]."-".$dbReg->[3],
+              $dbReg->[5],
+              $overlap;
           print $OVERLAP $eString;
           print STDERR $eString;
 	  $error++;

--- a/Rfam/Scripts/svn/rfnew.pl
+++ b/Rfam/Scripts/svn/rfnew.pl
@@ -141,11 +141,10 @@ my $overlapIgnore = {};
 
 #Okay, this a full check-in, perform whole QC repetoire.
 $error = Bio::Rfam::QC::essential($newFamObj, "$pwd/$family", undef, $config);
-  die "Failed essential QC step.\n" if($error);
+die "Failed essential QC step.\n" if($error);
 $error = Bio::Rfam::QC::optional( $newFamObj, "$pwd/$family", undef, 
                                     $config, $overrideHashRef, $overlapIgnore );
 die "Failed QC step.\n" if($error);
-
 
 #Automatically write the 'new' message and add it the binding.
 open( M, ">.default" . $$ . "rfnew" )
@@ -201,7 +200,8 @@ print<<EOF;
   Aim: To perform quality control checks on a new family and add it to the SVN repository.
   
   -i <option>       - Ignore some of the QC steps to speed up check-in/get family through.
-                      Valid options are (probably): 'overlap', 'spell', 'coding', 'seed', 'missing', 'length'
+                      Valid options are (probably): 'overlap', 'spell', 'coding', 'seed', 'missing', 
+                      'length' and 'seedrf'
                       To skip more than one, use -i <s> multiple times
   -m                - Specify the message that describes the changes you have made to this family 
                       on the command line, avoid being prompted for it at a later satge.


### PR DESCRIPTION
Blake requested this feature, for more informative log messages.