### PR TITLE
Adds username to pre-commit.log file

### DIFF
--- a/Rfam/Scripts/svnhooks/pre-commit.pl
+++ b/Rfam/Scripts/svnhooks/pre-commit.pl
@@ -16,10 +16,10 @@ use Data::Printer;
 use Log::Log4perl qw(get_logger);
 
 # set up logging
-my $logger_conf = q(
+my $logger_conf = qq(
   log4perl.logger                         = DEBUG, FileAppender
   log4perl.appender.FileAppender          = Log::Log4perl::Appender::File
-  log4perl.appender.FileAppender.filename = /tmp/pre-commit.log
+  log4perl.appender.FileAppender.filename = /tmp/pre-commit.$ENV{USER}.log
   log4perl.appender.FileAppender.layout   = Log::Log4perl::Layout::PatternLayout
   log4perl.appender.FileAppender.layout.ConversionPattern = %d %F{1}: %M %L> %m %n
 );


### PR DESCRIPTION
For rfnew.pl and other scripts that do commits to SVN, the `/tmp/pre-commit.log` file will now be named `/tmp/pre-commit.<uname>.log` where `<uname>` is the user name, e.g. `/tmp/pre-commit.rfamprod.log`. This should help us avoid problems where a commit fails because the current user (e.g. `rfamprod`) does not have permission to overwrite an existing `/tmp/pre-commit.log` file that has been written by a different user, (e.g. `nawrocki`). 
