### PR TITLE
Fixes max lengths for rfamseq_acc and accession in Rfamseq table

### DIFF
--- a/Rfam/Schemata/RfamLive/ResultSet/Rfamseq.pm
+++ b/Rfam/Schemata/RfamLive/ResultSet/Rfamseq.pm
@@ -111,8 +111,8 @@ sub updateRfamseqFromFamilyObj {
 
       # enforce maximum number of characters for each value,
       # for overflows in description we just truncate, overflow in others are fatal
-      if(length($seed_name)   > 20)  { croak "ERROR in $sub_name, rfamseq_acc $seed_name exceeds 20 characters"; }
-      if(length($accession)   > 15)  { croak "ERROR in $sub_name, accession $accession exceeds 15 characters"; }
+      if(length($seed_name)   > 25)  { croak "ERROR in $sub_name, rfamseq_acc $seed_name exceeds 25 characters"; }
+      if(length($accession)   > 25)  { croak "ERROR in $sub_name, accession $accession exceeds 25 characters"; }
       if(length($version)     > 6)   { croak "ERROR in $sub_name, version $version exceeds 6 characters"; }
       if(length($ncbi_id)     > 10)  { croak "ERROR in $sub_name, ncbi_id $ncbi_id exceeds 10 characters"; }
       if(length($length)      > 10)  { croak "ERROR in $sub_name, length $length exceeds 10 characters"; }


### PR DESCRIPTION
Fixes check of `rfamseq_acc` and `accession` have maximum lengths to allow up to 25, not 20 and 15 as the table on read the docs showed.