### PR TITLE
Fix bug in Utils.pm

### DIFF
--- a/Rfam/Lib/Bio/Rfam/SVN/Client.pm
+++ b/Rfam/Lib/Bio/Rfam/SVN/Client.pm
@@ -856,9 +856,11 @@ sub familyLocation {
 
 sub newFamilyLocation {
   my ($self) = @_;
-  my $newFamilyUrl =
-    $self->{config}->svnRepos . $self->{config}->svnNewFamilies;
-  return ($newFamilyUrl);
+  my $repos = $self->{config}->svnRepos;
+  my $path  = $self->{config}->svnNewFamilies;
+  $repos =~ s{/+$}{};
+  $path  =~ s{^/+}{};
+  return "$repos/$path";
 }
 
 # Below here are all of the log message callbacks. There is a certain amount

--- a/Rfam/Lib/Bio/Rfam/Utils.pm
+++ b/Rfam/Lib/Bio/Rfam/Utils.pm
@@ -2533,11 +2533,13 @@ sub genbank_nse_lookup_and_md5 {
       croak "ERROR trying to fetch sequence info for $name from genbank, reached maximum allowed number of attempts ($nattempts)";
     }
   }
-  elsif($got_url !~ m/^>/) {
+
+  if(defined $got_url && $got_url !~ m/^>/) {
     # this shouldn't happen, if the sequence doesn't exist then $got_url should be undefined
     die "ERROR in genbank_nse_lookup_and_md5() get() returned a value that is not a sequence";
   }
-  else {
+
+  if(defined $got_url) {
     # if we get here: we know that $got_url is defined and starts with a ">",
     # so we know that a sequence named $name exists in GenBank
     $have_source_seq = 1;


### PR DESCRIPTION
Lines 2519-2535 enter when the first get() returns undef and run retries — but if a retry succeeds, the code exits the if block without ever entering the else that sets $have_source_seq = 1 and parses the FASTA. The elsif/else only run for the first get() attempt.

The fix is to restructure so FASTA processing runs regardless of which attempt succeeded.